### PR TITLE
Fix for when src_array was none

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -160,6 +160,10 @@ def raster_stats(vectors, raster, layer_num=0, band_num=1, nodata_value=None,
                 gdal.RasterizeLayer(rvds, [1], mem_layer, None, None, burn_values=[1], options = ['ALL_TOUCHED=False'])
             rv_array = rvds.ReadAsArray()
 
+            if src_array is None:
+                src_array = rv_array.copy()
+                src_array[:] = nodata_value
+                
             # Mask the source data array with our current feature
             # we take the logical_not to flip 0<->1 to get the correct mask effect
             # we also mask out nodata values explictly


### PR DESCRIPTION
I am not following some of the logic, so this is a hack of a fix for a problem that I was having. I think this fix is minimally disruptive to everything else, but with more understanding could probably be handled in a better way.

Basically I was coming to a polygon that would result in src_array equal to 'None', which caused a failure in the creation of the 'masked' variable.  I just create a src_array of the correct size and populate with nodata_value.

This fix works for me.

Thank you for rasterstats.  It saved me a lot of work.

Kindest regards,
Tim
