### PR TITLE
Point query

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,14 +1,15 @@
 0.9.0
 - Completely removed osgeo.ogr in favor of fiona
 - Completely removed osgeo.osr, spatial referencing is external to this module
-- Loosened coupling with GeoRaster lib
+- Removed optional dependency on GeoRaster lib
 - Extensive cleanup of tests
-- Code refactoring and cleanup
-- Support for category maps to get human readable keys for categorical rasters 
+- Extensive refactoring to encapsulate coordinate transforms and data access
+- Use of affine lib instead of GDAL-style geotransform tuples
+- Support for category maps to get human readable keys for categorical rasters
 - Greatly improve speed of categorical and any stat requiring pixel counts
 - Simplified and sped up travis builds for faster feedback
-- Nones returned when polygon doesn't intersect raster pixels
-- Removed deprecated rasterstats script
+- Nones instead on nans returned when polygon doesn't intersect raster pixels
+- Removed deprecated rasterstats script and unused util functions
 - Added support for `nodata` count
 - GeoJSON features and geometries accepted as CLI inputs
 

--- a/src/rasterstats/__init__.py
+++ b/src/rasterstats/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .main import raster_stats, zonal_stats
+from .point import point_query
 from rasterstats import cli
 
-__all__ = ['raster_stats', 'zonal_stats', 'cli']
+__all__ = ['raster_stats', 'zonal_stats', 'point_query', 'cli']

--- a/src/rasterstats/cli.py
+++ b/src/rasterstats/cli.py
@@ -55,7 +55,7 @@ def zonalstats(input_geojson, raster, output_geojson, all_touched, band, categor
             feature_collection = {'type': 'FeatureCollection'}
         features = read_features(mapping)
     except (AssertionError, KeyError):
-        raise ValueError("input_geojson must be a GeoJSON Feature Collection")
+        raise ValueError("input_geojson must be valid GeoJSON")
 
     if stats is not None:
         stats = stats.split(" ")
@@ -78,4 +78,3 @@ def zonalstats(input_geojson, raster, output_geojson, all_touched, band, categor
 
     output_geojson.write(json.dumps(feature_collection, indent=indent))
     output_geojson.write("\n")
-

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -262,7 +262,6 @@ class Raster(object):
         if self.array is not None:
             # It's an ndarray already
             new_array = boundless_array(self.array, window=win, nodata=nodata)
-            # self.array[row_start:row_stop, col_start:col_stop]
         elif self.src:
             # It's an open rasterio dataset
             new_array = self.src.read(self.band, window=win, boundless=True)

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -184,7 +184,8 @@ def boundless_array(arr, window, nodata, masked=False):
     else:
         out[nr_start:nr_stop, nc_start:nc_stop] = arr[olr_start:olr_stop, olc_start:olc_stop]
 
-    # TODO handle masked
+    if masked:
+        out = np.ma.MaskedArray(out, mask=(out == nodata))
 
     return out
 

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -69,11 +69,6 @@ def parse_feature(obj):
     raise ValueError("Can't parse %s as a geojson Feature object" % obj)
 
 
-def geo_records(vectors):
-    for vector in vectors:
-        yield parse_feature(vector)
-
-
 def read_features(obj, layer=0):
     features_iter = None
     if isinstance(obj, string_types):
@@ -115,22 +110,16 @@ def read_features(obj, layer=0):
             features_iter = mapping['features']
         else:
             features_iter = [parse_feature(mapping)]
-    else:
-        # Single feature-like object
-        features_iter = [parse_feature(obj)]
 
     if not features_iter:
         raise ValueError("Object is not a recognized source of Features")
     return features_iter
 
 
-def read_featurecollection(obj, layer=0, lazy=False):
+def read_featurecollection(obj, layer=0):
     features = read_features(obj, layer=layer)
     fc = {'type': 'FeatureCollection', 'features': []}
-    if lazy:
-        fc['features'] = (f for f in features)
-    else:
-        fc['features'] = [f for f in features]
+    fc['features'] = [f for f in features]
     return fc
 
 
@@ -163,7 +152,7 @@ def boundless_array(arr, window, nodata):
     if len(arr.shape) == 3:
         dim3 = True
     elif len(arr.shape) != 2:
-        raise Exception
+        raise ValueError("Must be a 2D or 3D array")
 
     # unpack for readability
     (wr_start, wr_stop), (wc_start, wc_stop) = window
@@ -227,8 +216,6 @@ class Raster(object):
         elif self.src:
             # It's an open rasterio dataset
             new_array = self.src.read(self.band, window=win, boundless=True)
-        else:
-            raise Exception("Raster has neither a src nor an array, should never happen")
 
         return Raster(new_array, new_affine, nodata)
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -16,69 +16,79 @@ def raster_stats(*args, **kwargs):
     return zonal_stats(*args, **kwargs)
 
 
-def zonal_stats(vectors, raster, layer=0, band_num=1, nodata_value=None,
-                global_src_extent=False, categorical=False, stats=None,
-                copy_properties=False, all_touched=False, affine=None,
-                add_stats=None, raster_out=False, category_map=None, **kwargs):
-    """Summary statistics of a raster, broken out by vector geometries.
+def zonal_stats(vectors,
+                raster,
+                layer=0,
+                band_num=1,
+                nodata_value=None,
+                affine=None,
+                stats=None,
+                all_touched=False,
+                categorical=False,
+                category_map=None,
+                copy_properties=False,
+                add_stats=None,
+                raster_out=False,
+                **kwargs):
+    """Zonal statistics of raster values aggregated to vector geometries.
 
-    Attributes
+    Parameters
     ----------
-    vectors : path to an OGR vector source or list of geo_interface or WKT str
-    raster : ndarray or path to a GDAL raster source
+    vectors: path to an vector source or geo-like python objects
+
+    raster: ndarray or path to a GDAL raster source
         If ndarray is passed, the `transform` kwarg is required.
-    layer : int or string, optional
+
+    layer: int or string, optional
         If `vectors` is a path to an fiona source,
         specify the vector layer to use either by name or number.
         defaults to 0
-    band_num : int, optional
+
+    band_num: int, optional
         If `raster` is a GDAL source, the band number to use (counting from 1).
         defaults to 1.
-    nodata_value : float, optional
+
+    nodata_value: float, optional
         If `raster` is a GDAL source, this value overrides any NODATA value
         specified in the file's metadata.
         If `None`, the file's metadata's NODATA value (if any) will be used.
-        `ndarray`s don't support `nodata_value`.
         defaults to `None`.
-    global_src_extent : bool, optional
-        Pre-allocate entire raster before iterating over vector features.
-        Use `True` if limited by disk IO or indexing into raster;
-            requires sufficient RAM to store array in memory
-        Use `False` with fast disks and a well-indexed raster, or when
-        memory-constrained.
-        Ignored when `raster` is an ndarray,
-            because it is already completely in memory.
-        defaults to `False`.
-    categorical : bool, optional
-    stats : list of str, or space-delimited str, optional
+
+    affine: Affine object or 6 tuple in Affine order NOT GDAL order
+        required only for ndarrays, otherwise it is read from src
+
+    stats:  list of str, or space-delimited str, optional
         Which statistics to calculate for each zone.
         All possible choices are listed in `utils.VALID_STATS`.
         defaults to `DEFAULT_STATS`, a subset of these.
-    copy_properties : bool, optional
-        Include feature properties alongside the returned stats.
-        defaults to `False`
-    all_touched : bool, optional
+
+    all_touched: bool, optional
         Whether to include every raster cell touched by a geometry, or only
         those having a center point within the polygon.
         defaults to `False`
-    affine : Affine object or 6 tuple in Affine order NOT GDAL order
-        required only for ndarrays, otherwise it is read from src
-    add_stats : Dictionary with names and functions of additional statistics to
-                compute, optional
-    raster_out : Include the masked numpy array for each feature, optional
-        Each feature dictionary will have the following additional keys:
-            clipped raster (`mini_raster`)
-            Geo-transform (`mini_raster_GT`)
-            No Data Value (`mini_raster_NDV`)
-    category_map : A dictionary mapping raster values to human-readable categorical names
+
+    categorical: bool, optional
+
+    category_map: A dictionary mapping raster values to human-readable categorical names
         Only applies when categorical is True
+
+    copy_properties: bool, optional
+        Include feature properties alongside the returned stats.
+        defaults to `False`
+
+    add_stats: dict with names and functions of additional stats to compute, optional
+
+    raster_out: Include the masked numpy array for each feature, optional
+        Each feature dictionary will have the following additional keys:
+        mini_raster: The clipped and masked numpy array
+        mini_raster_affine: Affine transformation
+        mini_raster_nodata: NoData Value
 
     Returns
     -------
     list of dicts
-        Each dict represents one vector geometry.
-        Its keys include `__fid__` (the geometry feature id)
-        and each of the `stats` requested.
+        Each item corresponds to a single vector feature and
+        contains keys for each of the specified stats.
     """
     stats, run_count = check_stats(stats, categorical)
 

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
 import rasterio
 from shapely.geometry import shape
 from .io import read_features, raster_info
@@ -25,29 +28,23 @@ def _point_window_frc(x, y, rgt):
 
 
 def _bilinear(arr, frow, fcol):
-    """ Given a 2x2 array, return the value for the fractional row/col
-    using bilinear interpolation between the cells"
+    """ Given a 2x2 array, treat center points as a unit square
+    return the value for the fractional row/col
+    using bilinear interpolation between the cells
     """
     # for now, only 2x2 arrays
     assert arr.shape == (2, 2)
 
-    # convert rows, cols to cartesian coords on unit square
+    # convert fractional rows, cols to cartesian coords on unit square
     x = fcol
     y = 1 - frow
-    # use variables for clarity, todo optimize by replacement
-    x1 = 0
-    x2 = 1
-    y1 = 0
-    y2 = 1
 
     ulv, urv, llv, lrv = arr[0:2, 0:2].flatten().tolist()
 
-    fxy = ((llv * (x2 - x) * (y2 - y)) +
-           (lrv * (x - x1) * (y2 - y)) +
-           (ulv * (x2 - x) * (y - y1)) +
-           (urv * (x - x1) * (y - y1)))
-
-    return fxy
+    return ((llv * (1 - x) * (1 - y)) +
+            (lrv * x * (1 - y)) +
+            (ulv * (1 - x) * y) +
+            (urv * x * y))
 
 
 def point_query(vectors, raster, band_num=1, layer_num=1, interpolate='bilinear',

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -16,7 +16,7 @@ def point_window_unitxy(x, y, affine):
 
     ((row1, row2), (col1, col2)), (unitx, unity)
     """
-    frow, fcol = ~affine * (x, y)
+    fcol, frow = ~affine * (x, y)
     r, c = int(round(frow)), int(round(fcol))
 
     # The new source window for our 2x2 array

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -10,7 +10,7 @@ from numpy import asscalar
 from .io import read_features, raster_info
 
 
-def _point_window_frc(x, y, rgt):
+def point_window_frc(x, y, rgt):
     """ Given an x, y
     Returns
         - rasterio window representing 2x2 window whose center points encompass point
@@ -31,7 +31,7 @@ def _point_window_frc(x, y, rgt):
     return new_win, frc
 
 
-def _bilinear(arr, frow, fcol):
+def bilinear(arr, frow, fcol):
     """ Given a 2x2 array, treat center points as a unit square
     return the value for the fractional row/col
     using bilinear interpolation between the cells
@@ -106,9 +106,9 @@ def point_query(vectors, raster, band_num=1, layer_num=1, interpolate='bilinear'
                     geom = shape(feat['geometry'])
                     vals = []
                     for x, y in geom_xys(geom):
-                        window, frc = _point_window_frc(x, y, rgt)
+                        window, frc = point_window_frc(x, y, rgt)
                         src_array = src.read(band_num, window=window, masked=True)
-                        vals.append(_bilinear(src_array, *frc))
+                        vals.append(bilinear(src_array, *frc))
                     yield vals
             elif interpolate == 'nearest':
                 for feat in features_iter:

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -1,0 +1,85 @@
+import math
+import rasterio
+from shapely.geometry import shape
+from .io import read_features, raster_info
+
+
+def _point_window_frc(x, y, rgt):
+    """ Given an x, y
+    Returns
+        - rasterio window representing 2x2 window around a given point with point in UL
+        - the fractional row and col (frc) of the point in the new array
+
+    ((row1, row2), (col1, col2)), (frow, fcol)
+    """
+    c, a, b, f, d, e = rgt  # gdal-style translated to Affine nomenclature
+
+    frow, fcol = (y-f)/e, (x-c)/a
+    r, c = int(round(frow)), int(round(fcol))
+
+    new_win = ((r - 1, r + 1), (c - 1, c + 1))
+    frc = ( 0.5 - (r - frow), 0.5 - (c - fcol))  # the fractional row, col of the point
+    return new_win, frc
+
+
+def _bilinear(arr, frow, fcol):
+    """ Given an array, return the value for the fractional row/col
+    using bilinear interpolation between the cells"
+    """
+    # for now, only 2x2 arrays
+    assert arr.shape == (2, 2)
+
+    # convert rows, cols to cartesian coords on unit square
+    x = fcol
+    y = 1 - frow
+    # use variables for clarity, todo optimize by replacement
+    x1 = 0
+    x2 = 1
+    y1 = 0
+    y2 = 1
+
+    ulv, urv, llv, lrv = arr[0:2, 0:2].flatten().tolist()
+
+    fxy = ((llv * (x2 - x) * (y2 - y)) +
+           (lrv * (x - x1) * (y2 - y)) +
+           (ulv * (x2 - x) * (y - y1)) +
+           (urv * (x - x1) * (y - y1)))
+
+    return fxy
+
+
+def point_query(vectors, raster, band_num=1, layer_num=1, interpolate='bilinear',
+                nodata_value=None, affine=None, transform=None):
+    features_iter = read_features(vectors, layer_num)
+
+    rtype, rgt, rshape, global_src_extent, nodata_value = \
+        raster_info(raster, False, nodata_value, affine, transform)
+
+    for feat in features_iter:
+        geom = shape(feat['geometry'])
+
+        # TODO check if point, otherwise ???
+        window, frc = _point_window_frc(geom.x, geom.y, rgt)
+
+        with rasterio.drivers():
+            with rasterio.open(raster, 'r') as src:
+                src_array = src.read(band_num, window=window, masked=False)
+
+        val = _bilinear(src_array, *frc)
+        yield val
+
+        # TODO do we support global_src_extent? not yet...
+        # if not global_src_extent:
+        #     # use feature's source extent and read directly from source
+        #     window = pixel_offsets_to_window(src_offset)
+        #     with rasterio.drivers():
+        #         with rasterio.open(raster, 'r') as src:
+        #             src_array = src.read(
+        #                 band_num, window=window, masked=False)
+        # else:
+        #     # subset feature array from global source extent array
+        #     xa = src_offset[0] - global_src_offset[0]
+        #     ya = src_offset[1] - global_src_offset[1]
+        #     xb = xa + src_offset[2]
+        #     yb = ya + src_offset[3]
+        #     src_array = global_src_array[ya:yb, xa:xb]

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -74,13 +74,12 @@ def get_percentile(stat):
     return q
 
 
-def rasterize_geom(geom, src_offset, new_gt, all_touched):
+def rasterize_geom(geom, like, all_touched=False):
     geoms = [(geom, 1)]
-    affinetrans = Affine.from_gdal(*new_gt)
     rv_array = features.rasterize(
         geoms,
-        out_shape=(src_offset[3], src_offset[2]),
-        transform=affinetrans,
+        out_shape=like.shape,
+        transform=like.affine,
         fill=0,
         all_touched=all_touched)
     return rv_array

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -35,11 +35,7 @@ def rasterize_geom(geom, like, all_touched=False):
     return rv_array
 
 
-def is_nan(x):
-    return isinstance(x, float) and math.isnan(x)
-
-
-def combine_features_results(features, results, prefix, nan_to_None=True):
+def combine_features_results(features, results, prefix):
     """
     Given a list of geojson features and a list of zonal stats results
     Append the zonal stats to the feature's properties and yield a new feature
@@ -50,12 +46,6 @@ def combine_features_results(features, results, prefix, nan_to_None=True):
             if key == "__fid__":
                 continue
             prefixed_key = "{}{}".format(prefix, key)
-
-            # normalize for the sake of json-serializability
-            # TODO write test and is it even neccesary anymore?
-            if nan_to_None and is_nan(val):
-                val = None
-
             feat['properties'][prefixed_key] = val
         yield feat
 

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -12,56 +12,6 @@ VALID_STATS = DEFAULT_STATS + \
     ['sum', 'std', 'median', 'majority', 'minority', 'unique', 'range', 'nodata']
 #  also percentile_{q} but that is handled as special case
 
-
-def bbox_to_pixel_offsets(gt, bbox, rshape):
-    originX = gt[0]
-    originY = gt[3]
-    pixel_width = gt[1]
-    pixel_height = gt[5]
-
-    col1 = int(math.floor((bbox[0] - originX) / pixel_width))
-    col2 = int(math.ceil((bbox[2] - originX) / pixel_width))
-
-    row1 = int(math.floor((bbox[3] - originY) / pixel_height))
-    row2 = int(math.ceil((bbox[1] - originY) / pixel_height))
-
-    # "Clip" the geometry bounds to the overall raster bounding box
-    # This should avoid any rasterIO errors for partially overlapping polys
-    if col1 < 0:
-        col1 = 0
-    if col2 > rshape[0]:
-        col2 = rshape[0]
-    if row1 < 0:
-        row1 = 0
-    if row2 > rshape[1]:
-        row2 = rshape[1]
-
-    cols = col2 - col1
-    rows = row2 - row1
-
-    return (col1, row1, cols, rows)
-
-
-def pixel_offsets_to_window(offsets):
-    """
-    Convert (col1, row1, cols, rows)
-    to a rasterio-compatible window
-    https://github.com/mapbox/rasterio/blob/master/docs/windowed-rw.rst#windows
-    """
-    if len(offsets) != 4:
-        raise ValueError("offset should be a 4-element tuple")
-    col1, row1, cols, rows = offsets
-    return ((row1, row1 + rows), (col1, col1 + cols))
-
-
-def raster_extent_as_bounds(gt, shape):
-    x1 = gt[0]
-    x2 = gt[0] + (gt[1] * shape[0])
-    y1 = gt[3] + (gt[5] * shape[1])
-    y2 = gt[3]
-    return (x1, y1, x2, y2)
-
-
 def get_percentile(stat):
     if not stat.startswith('percentile_'):
         raise ValueError("must start with 'percentile_'")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -14,6 +14,14 @@ DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 polygons = os.path.join(DATA, 'polygons.shp')
 raster = os.path.join(DATA, 'slope.tif')
 
+import numpy as np
+arr = np.array([[1, 1, 1],
+                [1, 1, 1],
+                [1, 1, 1]])
+
+arr3d = np.array([[[1, 1, 1],
+                   [1, 1, 1],
+                   [1, 1, 1]]])
 
 with fiona.open(polygons, 'r') as src:
     target_features = [f for f in src]
@@ -175,14 +183,6 @@ def test_notafeature():
 
 # Raster tests
 def test_boundless():
-    import numpy as np
-    arr = np.array([[1, 1, 1],
-                    [1, 1, 1],
-                    [1, 1, 1]])
-
-    arr3d = np.array([[[1, 1, 1],
-                       [1, 1, 1],
-                       [1, 1, 1]]])
     # Exact
     assert boundless_array(arr, window=((0, 3), (0, 3)), nodata=0).sum() == 9
 
@@ -210,6 +210,15 @@ def test_boundless():
     # 1D
     with pytest.raises(ValueError):
         boundless_array(np.array([1, 1, 1]), window=((0, 3),), nodata=0)
+
+
+def test_boundless_masked():
+    a = boundless_array(arr, window=((-4, -1), (-4, -1)), nodata=0, masked=True)
+    assert a.mask.all()
+    b = boundless_array(arr, window=((0, 3), (0, 3)), nodata=0, masked=True)
+    assert not b.mask.any()
+    c = boundless_array(arr, window=((-1, 2), (-1, 2)), nodata=0, masked=True)
+    assert c.mask.any() and not c.mask.all()
 
 
 def test_window_bounds():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,7 @@ import json
 import pytest
 from shapely.geometry import shape
 from rasterstats.io import read_features, read_featurecollection, Raster  # todo parse_feature
-from rasterstats.io import boundless_array, window_bounds, window, rowcol
+from rasterstats.io import boundless_array, window_bounds, bounds_window, rowcol
 
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -221,9 +221,10 @@ def test_window_bounds():
         assert src.window_bounds(win) == window_bounds(win, src.affine)
 
 
-def test_window():
+def test_bounds_window():
     with rasterio.open(raster) as src:
-        assert window(src.bounds, src.affine) == ((0, src.shape[0]), (0, src.shape[1]))
+        assert bounds_window(src.bounds, src.affine) == \
+            ((0, src.shape[0]), (0, src.shape[1]))
 
 
 def test_rowcol():
@@ -234,6 +235,15 @@ def test_rowcol():
         y -= 1.0
         assert rowcol(x, y, src.affine, op=math.floor) == (0, 0)
         assert rowcol(x, y, src.affine, op=math.ceil) == (1, 1)
+
+def test_Raster_index():
+    x, y = 245114, 1000968
+    with rasterio.open(raster) as src:
+        c1, r1 = src.index(x, y)
+    with Raster(raster) as rast:
+        c2, r2 = rast.index(x, y)
+    assert c1 == c2
+    assert r1 == r2
 
 
 def test_Raster():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,7 +5,7 @@ import rasterio
 import json
 import pytest
 from shapely.geometry import shape
-from rasterstats.io import read_features, read_featurecollection  # todo parse_feature
+from rasterstats.io import read_features, read_featurecollection, Raster  # todo parse_feature
 from rasterstats.io import boundless_array, window_bounds, window, rowcol
 
 
@@ -234,6 +234,23 @@ def test_rowcol():
         y -= 1.0
         assert rowcol(x, y, src.affine, op=math.floor) == (0, 0)
         assert rowcol(x, y, src.affine, op=math.ceil) == (1, 1)
+
+
+def test_Raster():
+    import numpy as np
+
+    bounds = (244156, 1000258, 245114, 1000968)
+    r1 = Raster(raster, band=1).read(bounds)
+
+    with rasterio.open(raster) as src:
+        arr = src.read(1)
+        affine = src.affine
+        nodata = src.nodata
+
+    r2 = Raster(arr, affine, nodata, band=1).read(bounds)
+
+    # If the abstraction is correct, the arrays are equal
+    assert np.array_equal(r1.array, r2.array)
 
 
 # Optional tests

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -252,6 +252,17 @@ def test_Raster():
     # If the abstraction is correct, the arrays are equal
     assert np.array_equal(r1.array, r2.array)
 
+def test_Raster_context():
+    # Assigned a regular name, stays open
+    r1 = Raster(raster, band=1)
+    assert not r1.src.closed
+    r1.src.close()
+
+    # Used as a context manager, closes itself
+    with Raster(raster, band=1) as r2:
+        pass
+    assert r2.src.closed
+
 
 # Optional tests
 def test_geodataframe():

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,6 +1,7 @@
 import os
 import rasterio
-from rasterstats.point import _point_window_frc, point_query, _bilinear, geom_xys
+from rasterstats.point import point_window_frc, bilinear, geom_xys
+from rasterstats import point_query
 
 raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
 raster_nodata = os.path.join(os.path.dirname(__file__), 'data/slope_nodata.tif')
@@ -9,34 +10,34 @@ with rasterio.open(raster) as src:
     rgt = src.affine.to_gdal()
 
 def test_frc_ul():
-    win, frc = _point_window_frc(245300, 1000073, rgt)
+    win, frc = point_window_frc(245300, 1000073, rgt)
     assert win == ((30, 32), (38, 40))
     frow, fcol = frc
     assert frow > 0.5
     assert fcol > 0.5
 
 def test_frc_ur():
-    win, frc = _point_window_frc(245318, 1000073, rgt)
+    win, frc = point_window_frc(245318, 1000073, rgt)
     assert win == ((30, 32), (39, 41))
     frow, fcol = frc
     assert frow > 0.5
     assert fcol < 0.5
 
-    win, frc = _point_window_frc(245296, 1000073, rgt)
+    win, frc = point_window_frc(245296, 1000073, rgt)
     assert win == ((30, 32), (38, 40))
     frow, fcol = frc
     assert frow > 0.5
     assert fcol < 0.5
 
 def test_frc_lr():
-    win, frc = _point_window_frc(245318, 1000056, rgt)
+    win, frc = point_window_frc(245318, 1000056, rgt)
     assert win == ((31, 33), (39, 41))
     frow, fcol = frc
     assert frow < 0.5
     assert fcol < 0.5
 
 def test_frc_ll():
-    win, frc = _point_window_frc(245300, 1000056, rgt)
+    win, frc = point_window_frc(245300, 1000056, rgt)
     assert win == ((31, 33), (38, 40))
     frow, fcol = frc
     assert frow < 0.5
@@ -47,13 +48,13 @@ def test_bilinear():
     arr = np.array([[1.0, 2.0],
                     [3.0, 4.0]])
 
-    assert _bilinear(arr, 0, 0) == arr[0, 0]
-    assert _bilinear(arr, 1, 0) == arr[1, 0]
-    assert _bilinear(arr, 1, 1) == arr[1, 1]
-    assert _bilinear(arr, 0, 1) == arr[0, 1]
-    assert _bilinear(arr, 0.5, 0.5) == arr.mean()
-    assert _bilinear(arr, 0.95, 0.95) < arr[1, 1]
-    assert _bilinear(arr, 0.05, 0.05) > arr[0, 0]
+    assert bilinear(arr, 0, 0) == arr[0, 0]
+    assert bilinear(arr, 1, 0) == arr[1, 0]
+    assert bilinear(arr, 1, 1) == arr[1, 1]
+    assert bilinear(arr, 0, 1) == arr[0, 1]
+    assert bilinear(arr, 0.5, 0.5) == arr.mean()
+    assert bilinear(arr, 0.95, 0.95) < arr[1, 1]
+    assert bilinear(arr, 0.05, 0.05) > arr[0, 0]
 
 def test_xy_array_bilinear_window():
     """ integration test
@@ -62,10 +63,10 @@ def test_xy_array_bilinear_window():
 
     with rasterio.open(raster) as src:
         rgt = src.affine.to_gdal()
-        win, frc = _point_window_frc(x, y, rgt)
+        win, frc = point_window_frc(x, y, rgt)
         arr = src.read(1, window=win)
 
-    val = _bilinear(arr, *frc)
+    val = bilinear(arr, *frc)
     assert round(val) == 74
 
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,0 +1,73 @@
+import os
+import rasterio
+from rasterstats.point import _point_window_frc, point_query, _bilinear
+
+raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
+
+with rasterio.open(raster) as src:
+    rgt = src.affine.to_gdal()
+
+def test_frc_ul():
+    win, frc = _point_window_frc(245300, 1000073, rgt)
+    assert win == ((30, 32), (38, 40))
+    frow, fcol = frc
+    assert frow > 0.5
+    assert fcol > 0.5
+
+def test_frc_ur():
+    win, frc = _point_window_frc(245318, 1000073, rgt)
+    assert win == ((30, 32), (39, 41))
+    frow, fcol = frc
+    assert frow > 0.5
+    assert fcol < 0.5
+
+    win, frc = _point_window_frc(245296, 1000073, rgt)
+    assert win == ((30, 32), (38, 40))
+    frow, fcol = frc
+    assert frow > 0.5
+    assert fcol < 0.5
+
+def test_frc_lr():
+    win, frc = _point_window_frc(245318, 1000056, rgt)
+    assert win == ((31, 33), (39, 41))
+    frow, fcol = frc
+    assert frow < 0.5
+    assert fcol < 0.5
+
+def test_frc_ll():
+    win, frc = _point_window_frc(245300, 1000056, rgt)
+    assert win == ((31, 33), (38, 40))
+    frow, fcol = frc
+    assert frow < 0.5
+    assert fcol > 0.5
+
+def test_bilinear():
+    import numpy as np
+    arr = np.array([[1.0, 2.0],
+                    [3.0, 4.0]])
+
+    assert _bilinear(arr, 0, 0) == arr[0, 0]
+    assert _bilinear(arr, 1, 0) == arr[1, 0]
+    assert _bilinear(arr, 1, 1) == arr[1, 1]
+    assert _bilinear(arr, 0, 1) == arr[0, 1]
+    assert _bilinear(arr, 0.5, 0.5) == arr.mean()
+    assert _bilinear(arr, 0.95, 0.95) < arr[1, 1]
+    assert _bilinear(arr, 0.05, 0.05) > arr[0, 0]
+
+def test_xy_array_bilinear_window():
+    """ integration test
+    """
+    x, y = (245309, 1000064)
+
+    with rasterio.open(raster) as src:
+        rgt = src.affine.to_gdal()
+        win, frc = _point_window_frc(x, y, rgt)
+        arr = src.read(1, window=win)
+
+    val = _bilinear(arr, *frc)
+    assert round(val) == 74
+
+def test_point_query():
+    point = "POINT(245309 1000064)"
+    val = list(point_query(point, raster))[0]
+    assert round(val) == 74

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,6 +1,6 @@
 import os
 import rasterio
-from rasterstats.point import _point_window_frc, point_query, _bilinear
+from rasterstats.point import _point_window_frc, point_query, _bilinear, geom_xys
 
 raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
 
@@ -69,5 +69,27 @@ def test_xy_array_bilinear_window():
 
 def test_point_query():
     point = "POINT(245309 1000064)"
-    val = list(point_query(point, raster))[0]
+    val = list(point_query(point, raster))[0][0]
     assert round(val) == 74
+
+def test_geom_xys():
+    from shapely.geometry import (Point, MultiPoint,
+                                  LineString, MultiLineString,
+                                  Polygon, MultiPolygon)
+    pt = Point(0, 0)
+    assert list(geom_xys(pt)) == [(0, 0)]
+    mpt = MultiPoint([(0, 0), (1, 1)])
+    assert list(geom_xys(mpt)) == [(0, 0), (1, 1)]
+    line = LineString([(0, 0), (1, 1)])
+    assert list(geom_xys(line)) == [(0, 0), (1, 1)]
+    mline = MultiLineString([((0, 0), (1, 1)), ((-1, 0), (1, 0))])
+    assert list(geom_xys(mline)) == [(0, 0), (1, 1), (-1, 0), (1, 0)]
+    poly = Polygon([(0, 0), (1, 1), (1, 0)])
+    assert list(geom_xys(poly)) == [(0, 0), (1, 1), (1, 0), (0, 0)]
+    ring = poly.exterior
+    assert list(geom_xys(ring)) == [(0, 0), (1, 1), (1, 0), (0, 0)]
+    mpoly = MultiPolygon([poly, Polygon([(2, 2), (3, 3), (3, 2)])])
+    assert list(geom_xys(mpoly)) == [(0, 0), (1, 1), (1, 0), (0, 0),
+                                     (2, 2), (3, 3), (3, 2), (2, 2)]
+    mpt3d = MultiPoint([(0, 0, 1), (1, 1, 2)])
+    assert list(geom_xys(mpt3d)) == [(0, 0), (1, 1)]

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -7,10 +7,10 @@ raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
 raster_nodata = os.path.join(os.path.dirname(__file__), 'data/slope_nodata.tif')
 
 with rasterio.open(raster) as src:
-    rgt = src.affine.to_gdal()
+    affine = src.affine
 
 def test_unitxy_ul():
-    win, unitxy = point_window_unitxy(245300, 1000073, rgt)
+    win, unitxy = point_window_unitxy(245300, 1000073, affine)
     assert win == ((30, 32), (38, 40))
     x, y = unitxy
     # should be in LR of new unit square
@@ -18,14 +18,14 @@ def test_unitxy_ul():
     assert y < 0.5
 
 def test_unitxy_ur():
-    win, unitxy = point_window_unitxy(245318, 1000073, rgt)
+    win, unitxy = point_window_unitxy(245318, 1000073, affine)
     assert win == ((30, 32), (39, 41))
     x, y = unitxy
     # should be in LL of new unit square
     assert x < 0.5
     assert y < 0.5
 
-    win, unitxy = point_window_unitxy(245296, 1000073, rgt)
+    win, unitxy = point_window_unitxy(245296, 1000073, affine)
     assert win == ((30, 32), (38, 40))
     x, y = unitxy
     # should be in LL of new unit square
@@ -33,7 +33,7 @@ def test_unitxy_ur():
     assert y < 0.5
 
 def test_unitxy_lr():
-    win, unitxy = point_window_unitxy(245318, 1000056, rgt)
+    win, unitxy = point_window_unitxy(245318, 1000056, affine)
     assert win == ((31, 33), (39, 41))
     x, y = unitxy
     # should be in UL of new unit square
@@ -41,7 +41,7 @@ def test_unitxy_lr():
     assert y > 0.5
 
 def test_unitxy_ll():
-    win, unitxy = point_window_unitxy(245300, 1000056, rgt)
+    win, unitxy = point_window_unitxy(245300, 1000056, affine)
     assert win == ((31, 33), (38, 40))
     x, y = unitxy
     # should be in UR of new unit square
@@ -68,8 +68,8 @@ def test_xy_array_bilinear_window():
     x, y = (245309, 1000064)
 
     with rasterio.open(raster) as src:
-        rgt = src.affine.to_gdal()
-        win, unitxy = point_window_unitxy(x, y, rgt)
+        affine = src.affine.to_gdal()
+        win, unitxy = point_window_unitxy(x, y, affine)
         arr = src.read(1, window=win)
 
     val = bilinear(arr, *unitxy)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -3,6 +3,7 @@ import rasterio
 from rasterstats.point import _point_window_frc, point_query, _bilinear, geom_xys
 
 raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
+raster_nodata = os.path.join(os.path.dirname(__file__), 'data/slope_nodata.tif')
 
 with rasterio.open(raster) as src:
     rgt = src.affine.to_gdal()
@@ -67,10 +68,34 @@ def test_xy_array_bilinear_window():
     val = _bilinear(arr, *frc)
     assert round(val) == 74
 
+
 def test_point_query():
     point = "POINT(245309 1000064)"
     val = list(point_query(point, raster))[0][0]
     assert round(val) == 74
+
+
+def test_point_query_nodata():
+    # all nodata, on the grid
+    point = "POINT(245309 1000308)"
+    val = list(point_query(point, raster_nodata))[0][0]
+    assert val is None
+
+    # all nodata, off the grid
+    point = "POINT(244000 1000308)"
+    val = list(point_query(point, raster_nodata))[0][0]
+    assert val is None
+    point = "POINT(244000 1000308)"
+    val = list(point_query(point, raster_nodata, interpolate="nearest"))[0][0]
+    assert val is None
+
+    # some nodata, should fall back to nearest
+    point = "POINT(245905 1000361)"
+    val = list(point_query(point, raster_nodata, interpolate="nearest"))[0][0]
+    assert round(val) == 43
+    val = list(point_query(point, raster_nodata))[0][0]
+    assert round(val) == 43
+
 
 def test_geom_xys():
     from shapely.geometry import (Point, MultiPoint,

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -68,7 +68,6 @@ def test_xy_array_bilinear_window():
     x, y = (245309, 1000064)
 
     with rasterio.open(raster) as src:
-        affine = src.affine.to_gdal()
         win, unitxy = point_window_unitxy(x, y, affine)
         arr = src.read(1, window=win)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,7 @@
 import sys
 import os
 import pytest
-from rasterstats.utils import (stats_to_csv, bbox_to_pixel_offsets,
-                               get_percentile, remap_categories)
+from rasterstats.utils import stats_to_csv, get_percentile, remap_categories
 from rasterstats import zonal_stats
 from rasterstats.utils import VALID_STATS
 
@@ -27,24 +26,6 @@ def test_categorical_csv():
     assert csv.split()[0] == "1.0,2.0,5.0,__fid__"
 
 
-def test_bbox_offbyone():
-    # Make sure we don't get the off-by-one error in calculating src offset
-    rgt = (-4418000.0, 250.0, 0.0, 4876500.0, 0.0, -250.0)
-    geom_bounds = [4077943.9961, -3873500.0, 4462000.0055, -3505823.7582]
-    rshape = (37000, 35000)
-    so = bbox_to_pixel_offsets(rgt, geom_bounds, rshape)
-    assert so[1] + so[3] == rshape[1]
-
-    # Another great example
-    # based on https://github.com/perrygeo/python-raster-stats/issues/46
-    rgt = (151.2006, 0.025, 0.0, -25.4896, 0.0, -0.025)
-    geom_bounds = [153.39775866026284, -28.903022885889843,
-                   153.51344076545288, -28.80117672778147]
-    rshape = (92, 135)
-    # should only be 5 pixels wide, not 6 due to rounding errors
-    assert bbox_to_pixel_offsets(rgt, geom_bounds, rshape) == (87, 132, 5, 3)
-
-
 def test_get_percentile():
     assert get_percentile('percentile_0') == 0.0
     assert get_percentile('percentile_100') == 100.0
@@ -67,4 +48,3 @@ def test_remap_categories():
     assert 1 not in new_stats.keys()
     assert 'grassland' in new_stats.keys()
     assert 3 in new_stats.keys()
-

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -240,8 +240,11 @@ def _assert_dict_eq(a, b):
     for k in set(a.keys()).union(set(b.keys())):
         if a[k] == b[k]:
             continue
-        if abs(a[k]-b[k]) > err:
-            raise AssertionError("{}: {} != {}".format(k, a[k], b[k]))
+        try:
+            if abs(a[k]-b[k]) > err:
+                raise AssertionError("{}: {} != {}".format(k, a[k], b[k]))
+        except TypeError:  # can't take abs, nan
+            raise AssertionError("{} != {}".format(a[k], b[k]))
 
 
 def test_ndarray():


### PR DESCRIPTION
A working implementation of the point query functionality. Provides the ability to do either bilinear or nearest neighbor queries from point data (or other geometries which are treated as series of point data) against raster data.

This doesn't yet accept ndarrays and global_src_extent (a `src.read()` happens once per point). Not sure if that should block or if we can release this as is for 0.9?

resolves #69 