### PR TITLE
Treat geojson input in CLI as text, not binary

### DIFF
--- a/src/rasterstats/cli.py
+++ b/src/rasterstats/cli.py
@@ -17,7 +17,7 @@ version = 0.1
 
 
 @click.command(context_settings=SETTINGS)
-@click.argument('input-geojson', type=click.File('rb'), default='-')
+@click.argument('input-geojson', type=click.File('r'), default='-')
 @click.argument('output-geojson', type=click.File('w'), default='-')
 @click.version_option(version=version, message='%(version)s')
 @click.option('--raster', '-r', required=True, type=click.Path(exists=True))


### PR DESCRIPTION
Here is a bug fix for a problem that affects Python 3. A `geojson` input file is read as binary through the CLI, and reading like `input_geojson.read()` then returns a `bytes` object which is not accepted by `json.loads()`. I guess this is just a simple typo.

I have tested the new code in Python 2.7.8 and Python 3.4.3.

Thanks for writing and sharing great software!