### PR TITLE
fix the Raster.index docstring

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -246,7 +246,7 @@ class Raster(object):
                 self.nodata = self.src.nodata
 
     def index(self, x, y):
-        """Given x,y in crs, return the (column, row) on the raster
+        """ Given (x, y) in crs, return the (row, column) on the raster
         """
         col, row = [math.floor(a) for a in (~self.affine * (x, y))]
         return row, col


### PR DESCRIPTION
was: "returns col, row"
now: "returns row, col"

This now consistent with the existing implmentation and
the conventions for indexing arrays (in C-ish languages).