### PR TITLE
add zone_funcs to zonal_stats

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -90,7 +90,7 @@ def gen_zonal_stats(
         with names and functions of additional stats to compute, optional
 
     zone_func: callable
-        list of functions to apply to zone ndarray prior to computing stats
+        function to apply to zone ndarray prior to computing stats
 
     raster_out: boolean
         Include the masked numpy array for each feature?, optional

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -295,6 +295,24 @@ def test_percentile_good():
     assert stats[0]['percentile_50'] == stats[0]['median']
     assert stats[0]['percentile_50'] <= stats[0]['percentile_90']
 
+def test_zone_funcs_good():
+
+    def example_zone_func(zone_arr):
+        zone_arr[:] = 0
+
+    polygons = os.path.join(DATA, 'polygons.shp')
+    stats = zonal_stats(polygons,
+                        raster,
+                        zone_funcs=[example_zone_func])
+    assert stats[0]['max'] == 0
+    assert stats[0]['min'] == 0
+    assert stats[0]['mean'] == 0
+
+def test_zone_funcs_bad():
+    not_funcs = ['jar', 'jar', 'binks']
+    polygons = os.path.join(DATA, 'polygons.shp')
+    with pytest.raises(TypeError):
+        zonal_stats(polygons, raster, zone_funcs=not_funcs)
 
 def test_percentile_nodata():
     polygons = os.path.join(DATA, 'polygons.shp')

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -295,7 +295,8 @@ def test_percentile_good():
     assert stats[0]['percentile_50'] == stats[0]['median']
     assert stats[0]['percentile_50'] <= stats[0]['percentile_90']
 
-def test_zone_funcs_good():
+
+def test_zone_func_good():
 
     def example_zone_func(zone_arr):
         zone_arr[:] = 0
@@ -303,16 +304,16 @@ def test_zone_funcs_good():
     polygons = os.path.join(DATA, 'polygons.shp')
     stats = zonal_stats(polygons,
                         raster,
-                        zone_funcs=[example_zone_func])
+                        zone_func=example_zone_func)
     assert stats[0]['max'] == 0
     assert stats[0]['min'] == 0
     assert stats[0]['mean'] == 0
 
-def test_zone_funcs_bad():
-    not_funcs = ['jar', 'jar', 'binks']
+def test_zone_func_bad():
+    not_a_func = 'jar jar binks'
     polygons = os.path.join(DATA, 'polygons.shp')
     with pytest.raises(TypeError):
-        zonal_stats(polygons, raster, zone_funcs=not_funcs)
+        zonal_stats(polygons, raster, zone_func=not_a_func)
 
 def test_percentile_nodata():
     polygons = os.path.join(DATA, 'polygons.shp')


### PR DESCRIPTION
I recently found it helpful to have a hook to run arbitrary functions on the rasterized zone array.  I added an optional kwarg to `zonal_stats` called `zone_funcs` which expects a list of callables to apply to zone ndarray prior to calculating stats.