### PR TITLE
Feature splits

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -193,17 +193,10 @@ def gen_zonal_stats(
                 # need count for sub geoms to calculate weighted mean
                 if 'mean' in stats and not 'count' in stats:
                     stats.append('count')
+
                 pixel_size = rast.affine[0]
-                x_size = (geom_bounds[2] - geom_bounds[0]) / pixel_size
-                y_size = (geom_bounds[3] - geom_bounds[1]) / pixel_size
-                total_size = x_size * y_size
-
-                geom_list = split_geom(geom, limit, pixel_size)
-
-                # should be able to get rid of this if split_geom function is built properly
-                if len(geom_list) < 1:
-                    raise Exception("Error producing split geometries")
-
+                origin = (rast.affine[2], rast.affine[5])
+                geom_list = split_geom(geom, limit, pixel_size, origin=origin)
 
 
             # -----------------------------------------------------------------------------

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -248,7 +248,6 @@ def gen_zonal_stats(
                         pixel_count = dict(zip([np.asscalar(k) for k in keys],
                                                [np.asscalar(c) for c in counts]))
 
-
                     if categorical:
                         sub_feature_stats = dict(pixel_count)
                         if category_map:
@@ -359,9 +358,9 @@ def gen_zonal_stats(
                         for field in sub_stats:
                             if field not in VALID_STATS:
                                 if field not in feature_stats:
-                                    feature_stats[field] = sub_stats[field]
+                                    feature_stats[str(field)] = sub_stats[field]
                                 else:
-                                    feature_stats[field] += sub_stats[field]
+                                    feature_stats[str(field)] += sub_stats[field]
 
 
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -317,10 +317,6 @@ def gen_zonal_stats(
                     sub_feature_stats['mini_raster_affine'] = fsrc.affine
                     sub_feature_stats['mini_raster_nodata'] = fsrc.nodata
 
-
-                # print sub_feature_stats
-                # print sub_geom.bounds
-
                 sub_feature_stats_list.append(sub_feature_stats)
 
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -294,8 +294,10 @@ def gen_zonal_stats(
                     if 'unique' in stats:
                         sub_feature_stats['unique'] = len(list(pixel_count.keys()))
                     if 'range' in stats:
-                        rmin = sub_feature_stats['min']
-                        rmax = sub_feature_stats['max']
+                        rmin = float(masked.min())
+                        rmax = float(masked.max())
+                        sub_feature_stats['min'] = rmin
+                        sub_feature_stats['max'] = rmax
                         sub_feature_stats['range'] = rmax - rmin
 
                     for pctile in [s for s in stats if s.startswith('percentile_')]:
@@ -315,12 +317,17 @@ def gen_zonal_stats(
                 sub_feature_stats_list.append(sub_feature_stats)
 
 
-            # -----------------------------------------------------------------------------
+            # -----------------------------------------------------------------
             # aggregate sub geom extracts
 
             if len(geom_list) == 1:
 
                 feature_stats = sub_feature_stats
+
+                if 'range' in stats and not 'min' in stats:
+                    del feature_stats['min']
+                if 'range' in stats and not 'max' in stats:
+                    del feature_stats['max']
 
             else:
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -107,10 +107,14 @@ def gen_zonal_stats(
 
     limit: int
         maximum number of pixels allowed to be read from raster based on
-        feature bounds. Useful when dealing with vector data containing
+        feature bounds. Geometries which will result in reading a larger
+        number of pixels will be split into smaller geometries and then
+        aggregated (note: some stats and options cannot be used along with
+        `limit`. Useful when dealing with vector data containing
         large features and raster with a fine resolution to prevent
         memory errors. Estimated pixels per GB vary depending on options,
-        but a rough range is 5 to 80 million pixels per GB of memory.
+        but a rough range is 5 to 80 million pixels per GB of memory. If
+        values is None (default) geometries will never be split.
 
     geojson_out: boolean
         Return list of GeoJSON-like features (default: False)

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -359,9 +359,9 @@ def gen_zonal_stats(
                         for field in sub_stats:
                             if field not in VALID_STATS:
                                 if field not in feature_stats:
-                                    feature_stats[str(field)] = sub_stats[field]
+                                    feature_stats[field] = sub_stats[field]
                                 else:
-                                    feature_stats[str(field)] += sub_stats[field]
+                                    feature_stats[field] += sub_stats[field]
 
 
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -336,24 +336,28 @@ def gen_zonal_stats(
 
                 feature_stats = {}
 
-                if 'min' in stats:
-                    feature_stats['min'] = min([i['min'] for i in sub_feature_stats_list])
-                if 'max' in stats:
-                    feature_stats['max'] = max([i['max'] for i in sub_feature_stats_list])
                 if 'count' in stats:
                     feature_stats['count'] = sum([i['count'] for i in sub_feature_stats_list])
-                if 'sum' in stats:
-                    feature_stats['sum'] = sum([i['sum'] for i in sub_feature_stats_list])
+                if 'min' in stats:
+                    vals = [i['min'] for i in sub_feature_stats_list if i['min'] is not None]
+                    feature_stats['min'] = min(vals) if vals else None
+                if 'max' in stats:
+                    feature_stats['max'] = max([i['max'] for i in sub_feature_stats_list])
                 if 'range' in stats:
-                    rmin = min([i['min'] for i in sub_feature_stats_list])
+                    vals = [i['min'] for i in sub_feature_stats_list if i['min'] is not None]
+                    rmin = min(vals) if vals else None
                     rmax = max([i['max'] for i in sub_feature_stats_list])
-                    feature_stats['range'] = rmax - rmin
+                    feature_stats['range'] = rmax - rmin if rmin is not None else None
+                if 'mean' in stats:
+                    vals = [i['mean'] * i['count'] for i in sub_feature_stats_list if i['mean'] is not None]
+                    feature_stats['mean'] = sum(vals) / sum([i['count'] for i in sub_feature_stats_list]) if vals else None
+                if 'sum' in stats:
+                    vals = [i['sum'] for i in sub_feature_stats_list if i['sum'] is not None]
+                    feature_stats['sum'] = sum(vals) if vals else None
                 if 'nodata' in stats:
                     feature_stats['nodata'] = sum([i['nodata'] for i in sub_feature_stats_list])
                 if 'nan' in stats:
                     feature_stats['nan'] = sum([i['nan'] for i in sub_feature_stats_list])
-                if 'mean' in stats:
-                    feature_stats['mean'] = sum([i['mean'] * i['count'] for i in sub_feature_stats_list]) / sum([i['count'] for i in sub_feature_stats_list])
                 if categorical:
                     for sub_stats in sub_feature_stats_list:
                         for field in sub_stats:

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -293,11 +293,12 @@ def gen_zonal_stats(
                     featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
 
                     if 'nodata' in stats:
+
                         nodata_match = (featmasked == fsrc.nodata)
                         if nodata_match.count() == 0:
                             sub_feature_stats['nodata'] = 0
                         else:
-                            sub_feature_stats['nodata'] = nodata_match.sum()
+                            sub_feature_stats['nodata'] = float(nodata_match.sum())
 
                     if 'nan' in stats:
                         sub_feature_stats['nan'] = float(np.isnan(featmasked).sum()) if has_nan else 0

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -355,13 +355,13 @@ def gen_zonal_stats(
                 if 'mean' in stats:
                     feature_stats['mean'] = sum([i['mean'] * i['count'] for i in sub_feature_stats_list]) / sum([i['count'] for i in sub_feature_stats_list])
                 if categorical:
-                    for i in sub_feature_stats_list:
-                        for field, value, in i.iteritems():
+                    for sub_stats in sub_feature_stats_list:
+                        for field in sub_stats:
                             if field not in VALID_STATS:
                                 if field not in feature_stats:
-                                    feature_stats[field] = value
+                                    feature_stats[field] = sub_stats[field]
                                 else:
-                                    feature_stats[field] += value
+                                    feature_stats[field] += sub_stats[field]
 
 
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -213,15 +213,10 @@ def gen_zonal_stats(
 
                 sub_geom_bounds = tuple(sub_geom_box.bounds)
 
-                if 'Point' in sub_geom.type:
-                    sub_geom = boxify_points(sub_geom, rast)
-
-                sub_geom_bounds = tuple(sub_geom.bounds)
-
                 fsrc = rast.read(bounds=sub_geom_bounds)
 
                 # rasterized geometry
-                rv_array = rasterize_geom(sub_geom, like=fsrc, all_touched=all_touched)
+                rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)
 
                 # nodata mask
                 isnodata = (fsrc.array == fsrc.nodata)

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -148,11 +148,6 @@ def check_stats(stats, categorical):
                 "Stat `%s` not valid; "
                 "must be one of \n %r" % (x, VALID_STATS))
 
-    if 'range' in stats and not 'min' in stats:
-        stats.append('min')
-    if 'range' in stats and not 'max' in stats:
-        stats.append('max')
-
     run_count = False
     if categorical or 'majority' in stats or 'minority' in stats or 'unique' in stats:
         # run the counter once, only if needed

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -63,15 +63,15 @@ def split_geom(geom, limit, pixel_size):
         box_b_bounds = (gb[0], y_split, gb[2], gb[3])
 
 
-    geom_a = box(*box_a_bounds)
-    # geom_a = geom.intersection(box_a)
-    split_a = split_geom(geom_a)
+    box_a = box(*box_a_bounds)
+    geom_a = geom.intersection(box_a)
+    split_a = split_geom(geom_a, limit, pixel_size)
     split_geom_list += split_a
 
 
-    geom_b = box(*box_b_bounds)
-    # geom_b = geom.intersection(box_b)
-    split_b = split_geom(geom_b)
+    box_b = box(*box_b_bounds)
+    geom_b = geom.intersection(box_b)
+    split_b = split_geom(geom_b, limit, pixel_size)
     split_geom_list += split_b
 
     return split_geom_list

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -62,12 +62,10 @@ def split_geom(geom, limit, pixel_size):
         box_a_bounds = (gb[0], gb[1], gb[2], y_split)
         box_b_bounds = (gb[0], y_split, gb[2], gb[3])
 
-
     box_a = box(*box_a_bounds)
     geom_a = geom.intersection(box_a)
     split_a = split_geom(geom_a, limit, pixel_size)
     split_geom_list += split_a
-
 
     box_b = box(*box_b_bounds)
     geom_b = geom.intersection(box_b)
@@ -75,7 +73,6 @@ def split_geom(geom, limit, pixel_size):
     split_geom_list += split_b
 
     return split_geom_list
-
 
 
 def rasterize_geom(geom, like, all_touched=False):

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -29,14 +29,17 @@ def split_geom(geom, limit, pixel_size):
     """ split geometry into smaller geometries
 
     used to convert large features into multiple smaller features
-    so that they can be used in an extract job without running
-    into memory limits
+    so that they can be used without running into memory limits
 
+    Parameters
+    ----------
     geom: geometry
     limit: maximum number of pixels
     pixel_size: pixel size of raster data geometry will be extracting
 
-    returns: list of geometries
+    Returns
+    -------
+    list of geometries
     """
     split_geom_list = []
 

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -42,11 +42,12 @@ def round_to_grid(point, origin, pixel_size):
     """
     x_val, y_val = point
     x_origin, y_origin = origin
-    if x_val < x_origin or y_val < y_origin:
-        raise Exception("Longitude/latitude values for point cannot be less than "
-                        "the longitude/latitude values for the origin.")
+    if x_val < x_origin or y_val > y_origin:
+        raise Exception("Longitude/latitude values for point cannot be outside "
+                        "the box with upper left corner defined by origin "
+                        "[point: {0}, origin: {1}].".format(point, origin))
     adj_x_val = round((x_val - x_origin) / pixel_size) * pixel_size + x_origin
-    adj_y_val = round((y_val - y_origin) / pixel_size) * pixel_size + y_origin
+    adj_y_val = y_origin - round((y_origin - y_val) / pixel_size) * pixel_size
     return (adj_x_val, adj_y_val)
 
 
@@ -80,25 +81,28 @@ def split_geom(geom, limit, pixel_size, origin=None):
     if x_size > y_size:
         x_split = gb[2] - (gb[2]-gb[0])/2
         if origin is not None:
-            x_split = round_to_grid((x_split, origin[1]), origin, pixel_size)[0]
-        box_a_bounds = (gb[0], gb[1], x_split, gb[3])
-        box_b_bounds = (x_split, gb[1], gb[2], gb[3])
+            x_split, _ = round_to_grid((x_split, origin[1]), origin, pixel_size)
+        box_a_bounds = (gb[0], gb[1], x_split-pixel_size*0.0000001, gb[3])
+        box_b_bounds = (x_split+pixel_size*0.0000001, gb[1], gb[2], gb[3])
 
     else:
         y_split = gb[3] - (gb[3]-gb[1])/2
         if origin is not None:
-            y_split = round_to_grid((origin[0], y_split), origin, pixel_size)[1]
-        box_a_bounds = (gb[0], gb[1], gb[2], y_split)
-        box_b_bounds = (gb[0], y_split, gb[2], gb[3])
+            _, y_split = round_to_grid((origin[0], y_split), origin, pixel_size)
+        box_a_bounds = (gb[0], gb[1], gb[2], y_split-pixel_size*0.0000001)
+        box_b_bounds = (gb[0], y_split+pixel_size*0.0000001, gb[2], gb[3])
 
+    # minx, miny, maxx, maxy
     box_a = box(*box_a_bounds)
-    geom_a = geom.intersection(box_a)
-    split_a = split_geom(geom_a, limit, pixel_size)
+    split_a = split_geom(box_a, limit, pixel_size, origin=origin)
+    # geom_a = geom.intersection(box_a)
+    # split_a = split_geom(geom_a, limit, pixel_size, origin=origin)
     split_geom_list += split_a
 
     box_b = box(*box_b_bounds)
-    geom_b = geom.intersection(box_b)
-    split_b = split_geom(geom_b, limit, pixel_size)
+    split_b = split_geom(box_b, limit, pixel_size, origin=origin)
+    # geom_b = geom.intersection(box_b)
+    # split_b = split_geom(geom_b, limit, pixel_size, origin=origin)
     split_geom_list += split_b
 
     return split_geom_list

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -349,7 +349,6 @@ def test_json_serializable():
     stats = zonal_stats(polygons, raster,
                         stats=VALID_STATS + ["percentile_90"],
                         categorical=True)
-    print(stats)
     try:
         json.dumps(stats)
         simplejson.dumps(stats)

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -349,6 +349,7 @@ def test_json_serializable():
     stats = zonal_stats(polygons, raster,
                         stats=VALID_STATS + ["percentile_90"],
                         categorical=True)
+    print(stats)
     try:
         json.dumps(stats)
         simplejson.dumps(stats)

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -488,7 +488,7 @@ def test_copy_properties_warn():
     with pytest.deprecated_call():
         stats_b = zonal_stats(polygons, raster, copy_properties=True)
     assert stats_a == stats_b
-    
+
 
 def test_nan_counts():
     from affine import Affine
@@ -520,7 +520,9 @@ def test_nan_counts():
         assert 'nan' not in res
 
 
+# -----------------------------------------------------------------------------
 # Optional tests
+
 def test_geodataframe_zonal():
     polygons = os.path.join(DATA, 'polygons.shp')
 
@@ -535,3 +537,30 @@ def test_geodataframe_zonal():
     expected = zonal_stats(polygons, raster)
     assert zonal_stats(df, raster) == expected
 
+
+# -----------------------------------------------------------------------------
+# test geom splits
+
+def test_geom_split_main():
+    polygons = os.path.join(DATA, 'polygons.shp')
+    stats1 = zonal_stats(polygons, raster)
+    stats2 = zonal_stats(polygons, raster, limit=50)
+    for key in ['count', 'min', 'max', 'mean']:
+        assert key in stats1[0]
+        assert key in stats2[0]
+    assert len(stats1) == len(stats2) == 2
+    assert stats1[0]['count'] == stats2[0]['count'] == 75
+    assert stats1[1]['count'] == stats2[1]['count'] == 50
+    assert stats1[0]['min'] == stats2[0]['min']
+    assert stats1[0]['max'] == stats2[0]['max']
+    assert round(stats1[0]['mean'], 2) == round(stats2[0]['mean'], 2) == 14.66
+
+
+def test_geom_split_categorical():
+    polygons = os.path.join(DATA, 'polygons.shp')
+    categorical_raster = os.path.join(DATA, 'slope_classes.tif')
+    stats1 = zonal_stats(polygons, categorical_raster, categorical=True)
+    stats2 = zonal_stats(polygons, categorical_raster, categorical=True, limit=50)
+    assert len(stats1) == len(stats2) == 2
+    assert stats1[0][1.0] == stats2[0][1.0]  == 75
+    assert 5.0 in stats1[1] and 5.0 in stats2[1]


### PR DESCRIPTION
This branch is aimed at running rasterstats on systems which are memory limited. It adds an option called `limit` which enforces a maximum number of pixels that can be read from a raster by any individual feature. 

When a feature needs to read more pixels than the limit (predicated using raster pixel size and feature bounding box) the feature is split by cutting the bounding box in half along whichever dimension is larger and then taking the intersection of each half with the original feature. This runs recursively on the sub features resulting in a list of features that are all within the limit. 

The stats for each sub feature are saved while the remaining sub features are processed, and then they are all aggregated. Using this option limits which stats you can use due to aggregation methods (calculating mean, max, sum is much easier than std, majority, unique); using the raster_out and add_stats options will not work with the limit option either. An exception is raised if user attempts to use incompatible options.

Includes new tests to cover functionality, is fully backwards compatible and user will not notice any difference in output format. Actual results may be slightly off depending on the stats selected (e.g., min/max will be perfect, mean may be slightly off - in the examples used for the tests, it is accurate our to 6 decimal points, but this varies depending on the scale of the data).

If you end up wanting to merge this along with one or both of my other pull requests, I have them already merged on my fork and can create a new pull request 
