### PR TITLE
Remove use of deprecated functionality

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -162,7 +162,7 @@ def gen_zonal_stats(
 
             # add nan mask (if necessary)
             has_nan = (
-                np.issubdtype(fsrc.array.dtype, float)
+                np.issubdtype(fsrc.array.dtype, np.floating)
                 and np.isnan(fsrc.array.min()))
             if has_nan:
                 isnodata = (isnodata | np.isnan(fsrc.array))


### PR DESCRIPTION
The existing code produced the following warning, this commit removes the warning.

```
FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
```