### PR TITLE
Fix boxify_points to correctly use a negative buffer

### DIFF
--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -133,7 +133,7 @@ def boxify_points(geom, rast):
     if 'Point' not in geom.type:
         raise ValueError("Points or multipoints only")
 
-    buff = -0.01 * min(rast.affine.a, rast.affine.e)
+    buff = -0.01 * abs(min(rast.affine.a, rast.affine.e))
 
     if geom.type == 'Point':
         pts = [geom]


### PR DESCRIPTION
The following line in the `boxify_points` utils function was creating a positive buffer value since the `min` of the cell size dimensions is already a negative number. This was resulting in a buffered pixel box that would overlap with surrounding cells when using `all_touched`.

`buff = -0.01 * min(rast.affine.a, rast.affine.e)`

