### PR TITLE
Require Rasterio 1.0

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -105,7 +105,7 @@ to a coordinate reference system::
 
     >>> import rasterio
     >>> with rasterio.open('tests/data/slope.tif') as src:
-    ...     affine = src.affine
+    ...     affine = src.transform
     ...     array = src.read(1)
     >>> zs = zonal_stats('tests/data/polygons.shp', array, affine=affine)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 shapely
 numpy>=1.9
-rasterio>=0.27
+rasterio>=1.0
 cligj>=0.4
 fiona
 simplejson

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -224,15 +224,15 @@ def test_boundless_masked():
 def test_window_bounds():
     with rasterio.open(raster) as src:
         win = ((0, src.shape[0]), (0, src.shape[1]))
-        assert src.bounds == window_bounds(win, src.affine)
+        assert src.bounds == window_bounds(win, src.transform)
 
         win = ((5, 10), (5, 10))
-        assert src.window_bounds(win) == window_bounds(win, src.affine)
+        assert src.window_bounds(win) == window_bounds(win, src.transform)
 
 
 def test_bounds_window():
     with rasterio.open(raster) as src:
-        assert bounds_window(src.bounds, src.affine) == \
+        assert bounds_window(src.bounds, src.transform) == \
             ((0, src.shape[0]), (0, src.shape[1]))
 
 
@@ -242,8 +242,8 @@ def test_rowcol():
         x, _, _, y = src.bounds
         x += 1.0
         y -= 1.0
-        assert rowcol(x, y, src.affine, op=math.floor) == (0, 0)
-        assert rowcol(x, y, src.affine, op=math.ceil) == (1, 1)
+        assert rowcol(x, y, src.transform, op=math.floor) == (0, 0)
+        assert rowcol(x, y, src.transform, op=math.ceil) == (1, 1)
 
 def test_Raster_index():
     x, y = 245114, 1000968
@@ -263,7 +263,7 @@ def test_Raster():
 
     with rasterio.open(raster) as src:
         arr = src.read(1)
-        affine = src.affine
+        affine = src.transform
         nodata = src.nodata
 
     r2 = Raster(arr, affine, nodata, band=1).read(bounds)

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -7,7 +7,8 @@ raster = os.path.join(os.path.dirname(__file__), 'data/slope.tif')
 raster_nodata = os.path.join(os.path.dirname(__file__), 'data/slope_nodata.tif')
 
 with rasterio.open(raster) as src:
-    affine = src.affine
+    affine = src.transform
+
 
 def test_unitxy_ul():
     win, unitxy = point_window_unitxy(245300, 1000073, affine)
@@ -16,6 +17,7 @@ def test_unitxy_ul():
     # should be in LR of new unit square
     assert x > 0.5
     assert y < 0.5
+
 
 def test_unitxy_ur():
     win, unitxy = point_window_unitxy(245318, 1000073, affine)
@@ -32,6 +34,7 @@ def test_unitxy_ur():
     assert x < 0.5
     assert y < 0.5
 
+
 def test_unitxy_lr():
     win, unitxy = point_window_unitxy(245318, 1000056, affine)
     assert win == ((31, 33), (39, 41))
@@ -40,6 +43,7 @@ def test_unitxy_lr():
     assert x < 0.5
     assert y > 0.5
 
+
 def test_unitxy_ll():
     win, unitxy = point_window_unitxy(245300, 1000056, affine)
     assert win == ((31, 33), (38, 40))
@@ -47,6 +51,7 @@ def test_unitxy_ll():
     # should be in UR of new unit square
     assert x > 0.5
     assert y > 0.5
+
 
 def test_bilinear():
     import numpy as np

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -250,7 +250,7 @@ def _assert_dict_eq(a, b):
 def test_ndarray():
     with rasterio.open(raster) as src:
         arr = src.read(1)
-        affine = src.affine
+        affine = src.transform
 
     polygons = os.path.join(DATA, 'polygons.shp')
     stats = zonal_stats(polygons, arr, affine=affine)
@@ -412,7 +412,7 @@ def test_some_nodata_ndarray():
     raster = os.path.join(DATA, 'slope_nodata.tif')
     with rasterio.open(raster) as src:
         arr = src.read(1)
-        affine = src.affine
+        affine = src.transform
 
     # without nodata
     stats = zonal_stats(polygons, arr, affine=affine, stats=['nodata', 'count', 'min'])
@@ -431,7 +431,7 @@ def test_some_nodata_ndarray():
 def test_transform():
     with rasterio.open(raster) as src:
         arr = src.read(1)
-        affine = src.affine
+        affine = src.transform
     polygons = os.path.join(DATA, 'polygons.shp')
 
     stats = zonal_stats(polygons, arr, affine=affine)
@@ -456,7 +456,6 @@ def test_geojson_out():
         assert feature['type'] == 'Feature'
         assert 'id' in feature['properties']  # from orig
         assert 'count' in feature['properties']  # from zonal stats
-
 
 
 # do not think this is actually testing the line i wanted it to
@@ -488,7 +487,7 @@ def test_copy_properties_warn():
     with pytest.deprecated_call():
         stats_b = zonal_stats(polygons, raster, copy_properties=True)
     assert stats_a == stats_b
-    
+
 
 def test_nan_counts():
     from affine import Affine


### PR DESCRIPTION
The next version will require Rasterio 1.0.

This PR changes the code to use the `.transform` property instead of `.affine` on the Rasterio dataset object. 

Towards #155 - though we still use `affine` internally, all Rasterio usage is updated to use `transform`.