### PR TITLE
Updated method calls for numpy v1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - pip install -U pip setuptools --upgrade
   - pip install wheel
 install:
-  - if [[ "$NEWNUMPY" == true ]]; then pip install numpy>=1.16; fi
+  - if [[ "$NEWNUMPY" == true ]]; then pip install numpy==1.16; fi
   - pip install numpy "rasterio>=1.0a12"
   - pip install -r requirements_dev.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - pip install -U pip setuptools --upgrade
   - pip install wheel
 install:
-  - if [[ "$NEWNUMPY" = true ]]; then pip install numpy>=1.16; fi
+  - if [[ "$NEWNUMPY" == true ]]; then pip install numpy>=1.16; fi
   - pip install numpy "rasterio>=1.0a12"
   - pip install -r requirements_dev.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - python: 3.4
     - python: 3.5
     - python: 3.6
-    - python: 3.7
+    - python: 3.6
       env: NEWNUMPY=true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - pip install -U pip setuptools --upgrade
   - pip install wheel
 install:
-  - if [[ "$NEWNUMPY = true ]]; then pip install numpy>=1.16; fi
+  - if [[ "$NEWNUMPY" = true ]]; then pip install numpy>=1.16; fi
   - pip install numpy "rasterio>=1.0a12"
   - pip install -r requirements_dev.txt
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,20 @@ env:
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      env: NEWNUMPY=true
+
 before_install:
   - pip install -U pip setuptools --upgrade
   - pip install wheel
 install:
+  - if [[ "$NEWNUMPY = true ]]; then pip install numpy>=1.16; fi
   - pip install numpy "rasterio>=1.0a12"
   - pip install -r requirements_dev.txt
   - pip install coveralls

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
-from distutils.version import LooseVersion
 
 from affine import Affine
 from shapely.geometry import shape
@@ -198,12 +197,12 @@ def gen_zonal_stats(
             else:
                 if run_count:
                     keys, counts = np.unique(masked.compressed(), return_counts=True)
-                    if LooseVersion(np.__version__) < LooseVersion('1.16.0'):
-                        pixel_count = dict(zip([np.asscalar(k) for k in keys],
-                                               [np.asscalar(c) for c in counts]))
-                    else:
+                    try:
                         pixel_count = dict(zip([k.item() for k in keys],
                                                [c.item() for c in counts]))
+                    except AttributeError:
+                        pixel_count = dict(zip([np.asscalar(k) for k in keys],
+                                               [np.asscalar(c) for c in counts]))
 
                 if categorical:
                     feature_stats = dict(pixel_count)

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
+from distutils.version import LooseVersion
 
 from affine import Affine
 from shapely.geometry import shape
@@ -197,8 +198,12 @@ def gen_zonal_stats(
             else:
                 if run_count:
                     keys, counts = np.unique(masked.compressed(), return_counts=True)
-                    pixel_count = dict(zip([np.asscalar(k) for k in keys],
-                                           [np.asscalar(c) for c in counts]))
+                    if LooseVersion(np.__version__) < LooseVersion('1.16.0'):
+                        pixel_count = dict(zip([np.asscalar(k) for k in keys],
+                                               [np.asscalar(c) for c in counts]))
+                    else:
+                        pixel_count = dict(zip([k.item() for k in keys],
+                                               [c.item() for c in counts]))
 
                 if categorical:
                     feature_stats = dict(pixel_count)


### PR DESCRIPTION
Fixes #183 

Added a version check for numpy that either calls a now-deprecated method or the current standard method for returning scalars when parsing information from multi-feature shapefiles. Deprecated calls are maintained for backwards compatibility.