### PR TITLE
Do not create array with ones, and then multiply value by nodata.  In…

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -183,7 +183,8 @@ def boundless_array(arr, window, nodata, masked=False):
         window_shape = (wr_stop - wr_start, wc_stop - wc_start)
 
     # create an array of nodata values
-    out = np.ones(shape=window_shape) * nodata
+    out = np.empty(shape=window_shape)
+    out[:] = nodata
 
     # Fill with data where overlapping
     nr_start = olr_start - wr_start


### PR DESCRIPTION
In the boundless_array function in io.py, there is a line that creates an array with nodata values.

I am guessing this function gets called a lot in the usage of zonal_stats.

With the current way it is written:
`out = np.ones(shape=window_shape) * nodata`
Let's say shape has n values.  This operation will involve allocating memory for the array, perform copy 1 into memory n times (this is the initialization part in np.ones), perform 1 * nodata n times, and then perform memory copy of result of (1*nodata) n times (to put the results into the array).

If instead, we do this:
```
out = np.empty(shape=window_shape)
out[:] = nodata
```
Then, we are only doing the following:  allocate memory for array, perform n memory copy operations of writing nodata into each element of the array.

Indeed, a test shows this more than halves the operation time:
```
Python 3.7.6 | packaged by conda-forge | (default, Jan  7 2020, 22:05:27) 
[Clang 9.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import timeit
>>> timeit.timeit('out = np.ones(shape=(100,100)) * -999', setup='import numpy as np', number = 100000)
1.2897996959999993
>>> timeit.timeit('out = np.empty(shape=(100,100));out[:]=-999', setup='import numpy as np', number = 100000)
0.45873316300000155
>>> exit()
```

