### PR TITLE
Removing warnings from Python 3.8 installations

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     JSONDecodeError = ValueError
 from shapely import wkt, wkb
-from collections import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 
 geom_types = ["Point", "LineString", "Polygon",

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -154,8 +154,8 @@ def bounds_window(bounds, affine):
 
 def window_bounds(window, affine):
     (row_start, row_stop), (col_start, col_stop) = window
-    w, s = (col_start, row_stop) * affine
-    e, n = (col_stop, row_start) * affine
+    w, s = affine * (col_start, row_stop)
+    e, n = affine * (col_stop, row_start)
     return w, s, e, n
 
 


### PR DESCRIPTION
Dear maintainers of python-rasterstats,

I'm running Python 3.8 and get warnings about using the `collections` package directly for `Iterable` and `Mapping`. As suggested, they should be loaded from `collections.abc`.

Second, `rasterio` is deprecating "Right multiplication" so I fixed these two multiplications.

Let me know what you think.