### PR TITLE
Allow toggling off boundless reading

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -45,7 +45,8 @@ def gen_zonal_stats(
         zone_func=None,
         raster_out=False,
         prefix=None,
-        geojson_out=False, **kwargs):
+        geojson_out=False, 
+        boundless=True, **kwargs):
     """Zonal statistics of raster values aggregated to vector geometries.
 
     Parameters
@@ -111,7 +112,10 @@ def gen_zonal_stats(
         Original feature geometry and properties will be retained
         with zonal stats appended as additional properties.
         Use with `prefix` to ensure unique and meaningful property names.
-
+    
+    boundless: boolean
+        Allow features that extend beyond the raster dataset’s extent, default: True
+        Cells outside dataset extents are treated as nodata.
         
     Returns
     -------
@@ -153,7 +157,7 @@ def gen_zonal_stats(
 
             geom_bounds = tuple(geom.bounds)
 
-            fsrc = rast.read(bounds=geom_bounds)
+            fsrc = rast.read(bounds=geom_bounds, boundless=boundless)
 
             # rasterized geometry
             rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -106,7 +106,8 @@ def gen_point_query(
     affine=None,
     interpolate='bilinear',
     property_name='value',
-    geojson_out=False):
+    geojson_out=False,
+    boundless=True):
     """
     Given a set of vector features and a raster,
     generate raster values at each vertex of the geometry
@@ -154,6 +155,10 @@ def gen_point_query(
         original feature geometry and properties will be retained
         point query values appended as additional properties.
 
+    boundless: boolean
+        Allow features that extend beyond the raster dataset’s extent, default: True
+        Cells outside dataset extents are treated as nodata.
+
     Returns
     -------
     generator of arrays (if ``geojson_out`` is False)
@@ -173,7 +178,7 @@ def gen_point_query(
                 if interpolate == 'nearest':
                     r, c = rast.index(x, y)
                     window = ((int(r), int(r+1)), (int(c), int(c+1)))
-                    src_array = rast.read(window=window, masked=True).array
+                    src_array = rast.read(window=window, masked=True, boundless=boundless).array
                     val = src_array[0, 0]
                     if val is masked:
                         vals.append(None)
@@ -182,7 +187,7 @@ def gen_point_query(
 
                 elif interpolate == 'bilinear':
                     window, unitxy = point_window_unitxy(x, y, rast.affine)
-                    src_array = rast.read(window=window, masked=True).array
+                    src_array = rast.read(window=window, masked=True, boundless=boundless).array
                     vals.append(bilinear(src_array, *unitxy))
 
             if len(vals) == 1:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -290,6 +290,34 @@ def test_Raster():
     # If the abstraction is correct, the arrays are equal
     assert np.array_equal(r1.array, r2.array)
 
+def test_Raster_boundless_disabled():
+    import numpy as np
+
+    bounds = (244300.61494985913, 998877.8262535353, 246444.72726211764, 1000868.7876863468)
+    outside_bounds = (244156, 1000258, 245114, 1000968)
+
+    # rasterio src fails outside extent
+    with pytest.raises(ValueError):
+        r1 = Raster(raster, band=1).read(outside_bounds, boundless=False)
+
+    # rasterio src works inside extent
+    r2 = Raster(raster, band=1).read(bounds, boundless=False)
+
+    with rasterio.open(raster) as src:
+        arr = src.read(1)
+        affine = src.transform
+        nodata = src.nodata
+
+    # ndarray works inside extent
+    r3 = Raster(arr, affine, nodata, band=1).read(bounds, boundless=False)
+    
+    # ndarray src fails outside extent
+    with pytest.raises(ValueError):
+        r4 = Raster(arr, affine, nodata, band=1).read(outside_bounds, boundless=False)
+    
+    # If the abstraction is correct, the arrays are equal
+    assert np.array_equal(r2.array, r3.array)
+
 def test_Raster_context():
     # Assigned a regular name, stays open
     r1 = Raster(raster, band=1)


### PR DESCRIPTION
1) There are use cases where features being outside the raster extent is an error. For example in my job I am provided with countrywide rasters and I collect statistics from these rasters for buildings and roads. If a feature is outside the raster extent something is wrong with either the feature or the raster.

2) Enabling boundless reading in rasterio seriously degrades performance in some cases. It looks like the dataset is opened for each feature and the block cache is effectively disabled when using boundless reading. This gist https://gist.github.com/AsgerPetersen/6f9c8120b85e462ccbc26191a2117b3a demonstrates a performance improvement about 50x when disabling boundless reading.