### PR TITLE
Yield exception

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -144,148 +144,151 @@ def gen_zonal_stats(
         band = band_num
 
     with Raster(raster, affine, nodata, band) as rast:
-        features_iter = read_features(vectors, layer)
-        for _, feat in enumerate(features_iter):
-            geom = shape(feat['geometry'])
+        try:
+            features_iter = read_features(vectors, layer)
+            for _, feat in enumerate(features_iter):
+                geom = shape(feat['geometry'])
 
-            if 'Point' in geom.type:
-                geom = boxify_points(geom, rast)
+                if 'Point' in geom.type:
+                    geom = boxify_points(geom, rast)
 
-            geom_bounds = tuple(geom.bounds)
+                geom_bounds = tuple(geom.bounds)
 
-            fsrc = rast.read(bounds=geom_bounds)
+                fsrc = rast.read(bounds=geom_bounds)
 
-            # rasterized geometry
-            rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)
+                # rasterized geometry
+                rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)
 
-            # nodata mask
-            isnodata = (fsrc.array == fsrc.nodata)
+                # nodata mask
+                isnodata = (fsrc.array == fsrc.nodata)
 
-            # add nan mask (if necessary)
-            has_nan = (
-                np.issubdtype(fsrc.array.dtype, np.floating)
-                and np.isnan(fsrc.array.min()))
-            if has_nan:
-                isnodata = (isnodata | np.isnan(fsrc.array))
+                # add nan mask (if necessary)
+                has_nan = (
+                    np.issubdtype(fsrc.array.dtype, np.floating)
+                    and np.isnan(fsrc.array.min()))
+                if has_nan:
+                    isnodata = (isnodata | np.isnan(fsrc.array))
 
-            # Mask the source data array
-            # mask everything that is not a valid value or not within our geom
-            masked = np.ma.MaskedArray(
-                fsrc.array,
-                mask=(isnodata | ~rv_array))
+                # Mask the source data array
+                # mask everything that is not a valid value or not within our geom
+                masked = np.ma.MaskedArray(
+                    fsrc.array,
+                    mask=(isnodata | ~rv_array))
 
-            # If we're on 64 bit platform and the array is an integer type
-            # make sure we cast to 64 bit to avoid overflow.
-            # workaround for https://github.com/numpy/numpy/issues/8433
-            if sysinfo.platform_bits == 64 and \
-                    masked.dtype != np.int64 and \
-                    issubclass(masked.dtype.type, np.integer):
-                masked = masked.astype(np.int64)
+                # If we're on 64 bit platform and the array is an integer type
+                # make sure we cast to 64 bit to avoid overflow.
+                # workaround for https://github.com/numpy/numpy/issues/8433
+                if sysinfo.platform_bits == 64 and \
+                        masked.dtype != np.int64 and \
+                        issubclass(masked.dtype.type, np.integer):
+                    masked = masked.astype(np.int64)
 
-            # execute zone_func on masked zone ndarray
-            if zone_func is not None:
-                if not callable(zone_func):
-                    raise TypeError(('zone_func must be a callable '
-                                     'which accepts function a '
-                                     'single `zone_array` arg.'))
-                value = zone_func(masked)
+                # execute zone_func on masked zone ndarray
+                if zone_func is not None:
+                    if not callable(zone_func):
+                        raise TypeError(('zone_func must be a callable '
+                                         'which accepts function a '
+                                         'single `zone_array` arg.'))
+                    value = zone_func(masked)
 
-                # check if zone_func has return statement
-                if value is not None:
-                    masked = value
+                    # check if zone_func has return statement
+                    if value is not None:
+                        masked = value
 
-            if masked.compressed().size == 0:
-                # nothing here, fill with None and move on
-                feature_stats = dict([(stat, None) for stat in stats])
-                if 'count' in stats:  # special case, zero makes sense here
-                    feature_stats['count'] = 0
-            else:
-                if run_count:
-                    keys, counts = np.unique(masked.compressed(), return_counts=True)
-                    try:
-                        pixel_count = dict(zip([k.item() for k in keys],
-                                               [c.item() for c in counts]))
-                    except AttributeError:
-                        pixel_count = dict(zip([np.asscalar(k) for k in keys],
-                                               [np.asscalar(c) for c in counts]))
-
-                if categorical:
-                    feature_stats = dict(pixel_count)
-                    if category_map:
-                        feature_stats = remap_categories(category_map, feature_stats)
+                if masked.compressed().size == 0:
+                    # nothing here, fill with None and move on
+                    feature_stats = dict([(stat, None) for stat in stats])
+                    if 'count' in stats:  # special case, zero makes sense here
+                        feature_stats['count'] = 0
                 else:
-                    feature_stats = {}
+                    if run_count:
+                        keys, counts = np.unique(masked.compressed(), return_counts=True)
+                        try:
+                            pixel_count = dict(zip([k.item() for k in keys],
+                                                   [c.item() for c in counts]))
+                        except AttributeError:
+                            pixel_count = dict(zip([np.asscalar(k) for k in keys],
+                                                   [np.asscalar(c) for c in counts]))
 
-                if 'min' in stats:
-                    feature_stats['min'] = float(masked.min())
-                if 'max' in stats:
-                    feature_stats['max'] = float(masked.max())
-                if 'mean' in stats:
-                    feature_stats['mean'] = float(masked.mean())
-                if 'count' in stats:
-                    feature_stats['count'] = int(masked.count())
-                # optional
-                if 'sum' in stats:
-                    feature_stats['sum'] = float(masked.sum())
-                if 'std' in stats:
-                    feature_stats['std'] = float(masked.std())
-                if 'median' in stats:
-                    feature_stats['median'] = float(np.median(masked.compressed()))
-                if 'majority' in stats:
-                    feature_stats['majority'] = float(key_assoc_val(pixel_count, max))
-                if 'minority' in stats:
-                    feature_stats['minority'] = float(key_assoc_val(pixel_count, min))
-                if 'unique' in stats:
-                    feature_stats['unique'] = len(list(pixel_count.keys()))
-                if 'range' in stats:
-                    try:
-                        rmin = feature_stats['min']
-                    except KeyError:
-                        rmin = float(masked.min())
-                    try:
-                        rmax = feature_stats['max']
-                    except KeyError:
-                        rmax = float(masked.max())
-                    feature_stats['range'] = rmax - rmin
+                    if categorical:
+                        feature_stats = dict(pixel_count)
+                        if category_map:
+                            feature_stats = remap_categories(category_map, feature_stats)
+                    else:
+                        feature_stats = {}
 
-                for pctile in [s for s in stats if s.startswith('percentile_')]:
-                    q = get_percentile(pctile)
-                    pctarr = masked.compressed()
-                    feature_stats[pctile] = np.percentile(pctarr, q)
+                    if 'min' in stats:
+                        feature_stats['min'] = float(masked.min())
+                    if 'max' in stats:
+                        feature_stats['max'] = float(masked.max())
+                    if 'mean' in stats:
+                        feature_stats['mean'] = float(masked.mean())
+                    if 'count' in stats:
+                        feature_stats['count'] = int(masked.count())
+                    # optional
+                    if 'sum' in stats:
+                        feature_stats['sum'] = float(masked.sum())
+                    if 'std' in stats:
+                        feature_stats['std'] = float(masked.std())
+                    if 'median' in stats:
+                        feature_stats['median'] = float(np.median(masked.compressed()))
+                    if 'majority' in stats:
+                        feature_stats['majority'] = float(key_assoc_val(pixel_count, max))
+                    if 'minority' in stats:
+                        feature_stats['minority'] = float(key_assoc_val(pixel_count, min))
+                    if 'unique' in stats:
+                        feature_stats['unique'] = len(list(pixel_count.keys()))
+                    if 'range' in stats:
+                        try:
+                            rmin = feature_stats['min']
+                        except KeyError:
+                            rmin = float(masked.min())
+                        try:
+                            rmax = feature_stats['max']
+                        except KeyError:
+                            rmax = float(masked.max())
+                        feature_stats['range'] = rmax - rmin
 
-            if 'nodata' in stats or 'nan' in stats:
-                featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
+                    for pctile in [s for s in stats if s.startswith('percentile_')]:
+                        q = get_percentile(pctile)
+                        pctarr = masked.compressed()
+                        feature_stats[pctile] = np.percentile(pctarr, q)
 
-                if 'nodata' in stats:
-                    feature_stats['nodata'] = float((featmasked == fsrc.nodata).sum())
-                if 'nan' in stats:
-                    feature_stats['nan'] = float(np.isnan(featmasked).sum()) if has_nan else 0
+                if 'nodata' in stats or 'nan' in stats:
+                    featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
 
-            if add_stats is not None:
-                for stat_name, stat_func in add_stats.items():
-                    try:
-                        feature_stats[stat_name] = stat_func(masked, feat['properties'])
-                    except TypeError:
-                        # backwards compatible with single-argument function
-                        feature_stats[stat_name] = stat_func(masked)
+                    if 'nodata' in stats:
+                        feature_stats['nodata'] = float((featmasked == fsrc.nodata).sum())
+                    if 'nan' in stats:
+                        feature_stats['nan'] = float(np.isnan(featmasked).sum()) if has_nan else 0
 
-            if raster_out:
-                feature_stats['mini_raster_array'] = masked
-                feature_stats['mini_raster_affine'] = fsrc.affine
-                feature_stats['mini_raster_nodata'] = fsrc.nodata
+                if add_stats is not None:
+                    for stat_name, stat_func in add_stats.items():
+                        try:
+                            feature_stats[stat_name] = stat_func(masked, feat['properties'])
+                        except TypeError:
+                            # backwards compatible with single-argument function
+                            feature_stats[stat_name] = stat_func(masked)
 
-            if prefix is not None:
-                prefixed_feature_stats = {}
-                for key, val in feature_stats.items():
-                    newkey = "{}{}".format(prefix, key)
-                    prefixed_feature_stats[newkey] = val
-                feature_stats = prefixed_feature_stats
+                if raster_out:
+                    feature_stats['mini_raster_array'] = masked
+                    feature_stats['mini_raster_affine'] = fsrc.affine
+                    feature_stats['mini_raster_nodata'] = fsrc.nodata
 
-            if geojson_out:
-                for key, val in feature_stats.items():
-                    if 'properties' not in feat:
-                        feat['properties'] = {}
-                    feat['properties'][key] = val
-                yield feat
-            else:
-                yield feature_stats
+                if prefix is not None:
+                    prefixed_feature_stats = {}
+                    for key, val in feature_stats.items():
+                        newkey = "{}{}".format(prefix, key)
+                        prefixed_feature_stats[newkey] = val
+                    feature_stats = prefixed_feature_stats
+
+                if geojson_out:
+                    for key, val in feature_stats.items():
+                        if 'properties' not in feat:
+                            feat['properties'] = {}
+                        feat['properties'][key] = val
+                    yield feat
+                else:
+                    yield feature_stats
+        except Exception as exc:
+            yield exc

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -149,9 +149,9 @@ def gen_zonal_stats(
         band = band_num
 
     with Raster(raster, affine, nodata, band) as rast:
-        try:
-            features_iter = read_features(vectors, layer)
-            for _, feat in enumerate(features_iter):
+        features_iter = read_features(vectors, layer)
+        for _, feat in enumerate(features_iter):
+            try:
                 geom = shape(feat['geometry'])
 
                 if 'Point' in geom.type:
@@ -295,8 +295,8 @@ def gen_zonal_stats(
                     yield feat
                 else:
                     yield feature_stats
-        except Exception as exc:
-            if yield_exception:
-                yield exc
-            else:
-                raise exc
+            except Exception as exc:
+                if yield_exception:
+                    yield exc
+                else:
+                    raise exc

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -45,7 +45,8 @@ def gen_zonal_stats(
         zone_func=None,
         raster_out=False,
         prefix=None,
-        geojson_out=False, **kwargs):
+        geojson_out=False,
+        yield_exception=False, **kwargs):
     """Zonal statistics of raster values aggregated to vector geometries.
 
     Parameters
@@ -112,7 +113,11 @@ def gen_zonal_stats(
         with zonal stats appended as additional properties.
         Use with `prefix` to ensure unique and meaningful property names.
 
-        
+    yield_exception: boolean
+        Raise exceptions (default) or yield exceptions for handling without
+        triggering a StopIteration exception?, optional
+
+
     Returns
     -------
     generator of dicts (if geojson_out is False)
@@ -144,148 +149,154 @@ def gen_zonal_stats(
         band = band_num
 
     with Raster(raster, affine, nodata, band) as rast:
-        features_iter = read_features(vectors, layer)
-        for _, feat in enumerate(features_iter):
-            geom = shape(feat['geometry'])
+        try:
+            features_iter = read_features(vectors, layer)
+            for _, feat in enumerate(features_iter):
+                geom = shape(feat['geometry'])
 
-            if 'Point' in geom.type:
-                geom = boxify_points(geom, rast)
+                if 'Point' in geom.type:
+                    geom = boxify_points(geom, rast)
 
-            geom_bounds = tuple(geom.bounds)
+                geom_bounds = tuple(geom.bounds)
 
-            fsrc = rast.read(bounds=geom_bounds)
+                fsrc = rast.read(bounds=geom_bounds)
 
-            # rasterized geometry
-            rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)
+                # rasterized geometry
+                rv_array = rasterize_geom(geom, like=fsrc, all_touched=all_touched)
 
-            # nodata mask
-            isnodata = (fsrc.array == fsrc.nodata)
+                # nodata mask
+                isnodata = (fsrc.array == fsrc.nodata)
 
-            # add nan mask (if necessary)
-            has_nan = (
-                np.issubdtype(fsrc.array.dtype, np.floating)
-                and np.isnan(fsrc.array.min()))
-            if has_nan:
-                isnodata = (isnodata | np.isnan(fsrc.array))
+                # add nan mask (if necessary)
+                has_nan = (
+                    np.issubdtype(fsrc.array.dtype, np.floating)
+                    and np.isnan(fsrc.array.min()))
+                if has_nan:
+                    isnodata = (isnodata | np.isnan(fsrc.array))
 
-            # Mask the source data array
-            # mask everything that is not a valid value or not within our geom
-            masked = np.ma.MaskedArray(
-                fsrc.array,
-                mask=(isnodata | ~rv_array))
+                # Mask the source data array
+                # mask everything that is not a valid value or not within our geom
+                masked = np.ma.MaskedArray(
+                    fsrc.array,
+                    mask=(isnodata | ~rv_array))
 
-            # If we're on 64 bit platform and the array is an integer type
-            # make sure we cast to 64 bit to avoid overflow.
-            # workaround for https://github.com/numpy/numpy/issues/8433
-            if sysinfo.platform_bits == 64 and \
-                    masked.dtype != np.int64 and \
-                    issubclass(masked.dtype.type, np.integer):
-                masked = masked.astype(np.int64)
+                # If we're on 64 bit platform and the array is an integer type
+                # make sure we cast to 64 bit to avoid overflow.
+                # workaround for https://github.com/numpy/numpy/issues/8433
+                if sysinfo.platform_bits == 64 and \
+                        masked.dtype != np.int64 and \
+                        issubclass(masked.dtype.type, np.integer):
+                    masked = masked.astype(np.int64)
 
-            # execute zone_func on masked zone ndarray
-            if zone_func is not None:
-                if not callable(zone_func):
-                    raise TypeError(('zone_func must be a callable '
-                                     'which accepts function a '
-                                     'single `zone_array` arg.'))
-                value = zone_func(masked)
+                # execute zone_func on masked zone ndarray
+                if zone_func is not None:
+                    if not callable(zone_func):
+                        raise TypeError(('zone_func must be a callable '
+                                         'which accepts function a '
+                                         'single `zone_array` arg.'))
+                    value = zone_func(masked)
 
-                # check if zone_func has return statement
-                if value is not None:
-                    masked = value
+                    # check if zone_func has return statement
+                    if value is not None:
+                        masked = value
 
-            if masked.compressed().size == 0:
-                # nothing here, fill with None and move on
-                feature_stats = dict([(stat, None) for stat in stats])
-                if 'count' in stats:  # special case, zero makes sense here
-                    feature_stats['count'] = 0
-            else:
-                if run_count:
-                    keys, counts = np.unique(masked.compressed(), return_counts=True)
-                    try:
-                        pixel_count = dict(zip([k.item() for k in keys],
-                                               [c.item() for c in counts]))
-                    except AttributeError:
-                        pixel_count = dict(zip([np.asscalar(k) for k in keys],
-                                               [np.asscalar(c) for c in counts]))
-
-                if categorical:
-                    feature_stats = dict(pixel_count)
-                    if category_map:
-                        feature_stats = remap_categories(category_map, feature_stats)
+                if masked.compressed().size == 0:
+                    # nothing here, fill with None and move on
+                    feature_stats = dict([(stat, None) for stat in stats])
+                    if 'count' in stats:  # special case, zero makes sense here
+                        feature_stats['count'] = 0
                 else:
-                    feature_stats = {}
+                    if run_count:
+                        keys, counts = np.unique(masked.compressed(), return_counts=True)
+                        try:
+                            pixel_count = dict(zip([k.item() for k in keys],
+                                                   [c.item() for c in counts]))
+                        except AttributeError:
+                            pixel_count = dict(zip([np.asscalar(k) for k in keys],
+                                                   [np.asscalar(c) for c in counts]))
 
-                if 'min' in stats:
-                    feature_stats['min'] = float(masked.min())
-                if 'max' in stats:
-                    feature_stats['max'] = float(masked.max())
-                if 'mean' in stats:
-                    feature_stats['mean'] = float(masked.mean())
-                if 'count' in stats:
-                    feature_stats['count'] = int(masked.count())
-                # optional
-                if 'sum' in stats:
-                    feature_stats['sum'] = float(masked.sum())
-                if 'std' in stats:
-                    feature_stats['std'] = float(masked.std())
-                if 'median' in stats:
-                    feature_stats['median'] = float(np.median(masked.compressed()))
-                if 'majority' in stats:
-                    feature_stats['majority'] = float(key_assoc_val(pixel_count, max))
-                if 'minority' in stats:
-                    feature_stats['minority'] = float(key_assoc_val(pixel_count, min))
-                if 'unique' in stats:
-                    feature_stats['unique'] = len(list(pixel_count.keys()))
-                if 'range' in stats:
-                    try:
-                        rmin = feature_stats['min']
-                    except KeyError:
-                        rmin = float(masked.min())
-                    try:
-                        rmax = feature_stats['max']
-                    except KeyError:
-                        rmax = float(masked.max())
-                    feature_stats['range'] = rmax - rmin
+                    if categorical:
+                        feature_stats = dict(pixel_count)
+                        if category_map:
+                            feature_stats = remap_categories(category_map, feature_stats)
+                    else:
+                        feature_stats = {}
 
-                for pctile in [s for s in stats if s.startswith('percentile_')]:
-                    q = get_percentile(pctile)
-                    pctarr = masked.compressed()
-                    feature_stats[pctile] = np.percentile(pctarr, q)
+                    if 'min' in stats:
+                        feature_stats['min'] = float(masked.min())
+                    if 'max' in stats:
+                        feature_stats['max'] = float(masked.max())
+                    if 'mean' in stats:
+                        feature_stats['mean'] = float(masked.mean())
+                    if 'count' in stats:
+                        feature_stats['count'] = int(masked.count())
+                    # optional
+                    if 'sum' in stats:
+                        feature_stats['sum'] = float(masked.sum())
+                    if 'std' in stats:
+                        feature_stats['std'] = float(masked.std())
+                    if 'median' in stats:
+                        feature_stats['median'] = float(np.median(masked.compressed()))
+                    if 'majority' in stats:
+                        feature_stats['majority'] = float(key_assoc_val(pixel_count, max))
+                    if 'minority' in stats:
+                        feature_stats['minority'] = float(key_assoc_val(pixel_count, min))
+                    if 'unique' in stats:
+                        feature_stats['unique'] = len(list(pixel_count.keys()))
+                    if 'range' in stats:
+                        try:
+                            rmin = feature_stats['min']
+                        except KeyError:
+                            rmin = float(masked.min())
+                        try:
+                            rmax = feature_stats['max']
+                        except KeyError:
+                            rmax = float(masked.max())
+                        feature_stats['range'] = rmax - rmin
 
-            if 'nodata' in stats or 'nan' in stats:
-                featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
+                    for pctile in [s for s in stats if s.startswith('percentile_')]:
+                        q = get_percentile(pctile)
+                        pctarr = masked.compressed()
+                        feature_stats[pctile] = np.percentile(pctarr, q)
 
-                if 'nodata' in stats:
-                    feature_stats['nodata'] = float((featmasked == fsrc.nodata).sum())
-                if 'nan' in stats:
-                    feature_stats['nan'] = float(np.isnan(featmasked).sum()) if has_nan else 0
+                if 'nodata' in stats or 'nan' in stats:
+                    featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
 
-            if add_stats is not None:
-                for stat_name, stat_func in add_stats.items():
-                    try:
-                        feature_stats[stat_name] = stat_func(masked, feat['properties'])
-                    except TypeError:
-                        # backwards compatible with single-argument function
-                        feature_stats[stat_name] = stat_func(masked)
+                    if 'nodata' in stats:
+                        feature_stats['nodata'] = float((featmasked == fsrc.nodata).sum())
+                    if 'nan' in stats:
+                        feature_stats['nan'] = float(np.isnan(featmasked).sum()) if has_nan else 0
 
-            if raster_out:
-                feature_stats['mini_raster_array'] = masked
-                feature_stats['mini_raster_affine'] = fsrc.affine
-                feature_stats['mini_raster_nodata'] = fsrc.nodata
+                if add_stats is not None:
+                    for stat_name, stat_func in add_stats.items():
+                        try:
+                            feature_stats[stat_name] = stat_func(masked, feat['properties'])
+                        except TypeError:
+                            # backwards compatible with single-argument function
+                            feature_stats[stat_name] = stat_func(masked)
 
-            if prefix is not None:
-                prefixed_feature_stats = {}
-                for key, val in feature_stats.items():
-                    newkey = "{}{}".format(prefix, key)
-                    prefixed_feature_stats[newkey] = val
-                feature_stats = prefixed_feature_stats
+                if raster_out:
+                    feature_stats['mini_raster_array'] = masked
+                    feature_stats['mini_raster_affine'] = fsrc.affine
+                    feature_stats['mini_raster_nodata'] = fsrc.nodata
 
-            if geojson_out:
-                for key, val in feature_stats.items():
-                    if 'properties' not in feat:
-                        feat['properties'] = {}
-                    feat['properties'][key] = val
-                yield feat
+                if prefix is not None:
+                    prefixed_feature_stats = {}
+                    for key, val in feature_stats.items():
+                        newkey = "{}{}".format(prefix, key)
+                        prefixed_feature_stats[newkey] = val
+                    feature_stats = prefixed_feature_stats
+
+                if geojson_out:
+                    for key, val in feature_stats.items():
+                        if 'properties' not in feat:
+                            feat['properties'] = {}
+                        feat['properties'][key] = val
+                    yield feat
+                else:
+                    yield feature_stats
+        except Exception as exc:
+            if yield_exception:
+                yield exc
             else:
-                yield feature_stats
+                raise exc


### PR DESCRIPTION
cf #229 

This PR adds a try/except around the feature loop, and a boolean kwarg to `gen_zonal_stats` to control whether any exceptions raised during iteration should be raised (default) or yielded. If an exception is yielded, a consumer of the generator can do something with an exception (such as logging it) without causing the generator to terminate (i.e. to throw `StopIteration`), e.g.:

```python
zs = gen_zonal_stats(
    count_dataset, capacity_dataset,
    stats=['sum'], geojson_out=True, raster_out=True, layer=count_layer,
    all_touched=False, yield_exception=True
)
i = 0
while True:
    try:
        zone = next(zs)
        if isinstance(zone, Exception):
            raise zone
    except ValueError:
        # Raised by rasterstats.io.read when a feature has a null geometry 
        log.error(f'Error getting zonal stats for zone {i}, exc_info=True)
    except StopIteration:
        break
    else:
        foo_the_bar(zone)
    finally:
        i += 1
```

Since this introduces a new argument to `gen_zonal_stats` without changing the default behaviour, this is backwards compatible.

However I'm not sure how to correctly run the test suite, so I haven't run, modified, or added any tests (yet).

This solves an issue in my use case, where I was using `gen_zonal_stats` to iterate over features in a GeoPackage, some of which had null geometries. (It was a census dataset, which included composite counts for things like "offshore oil rigs", very remote terrorial islands, and an Antarctic dependency. These could be safely ignored for my purposes, but the existing behaviour meant I could not otherwise exhaust the generator to step through every feature.)