### PR TITLE
set dtype in new array creation

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -192,7 +192,7 @@ def boundless_array(arr, window, nodata, masked=False):
         window_shape = (wr_stop - wr_start, wc_stop - wc_start)
 
     # create an array of nodata values
-    out = np.empty(shape=window_shape)
+    out = np.empty(shape=window_shape, dtype=arr.dtype)
     out[:] = nodata
 
     # Fill with data where overlapping


### PR DESCRIPTION
If I pass a pre-loaded int array that's already pretty large, then it tends to have a memory error since the default for `np.empty` is float64. It seems reasonable to keep the dtype constant here. 