### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -85,7 +85,7 @@ for performing zonal statistics and point_queries at the command line.
 Example
 -----------
 
-In the following examples we use a polygon shapefile representing countries (``countries.shp``) and a raster digitial elevation model (``dem.tif``). The data are assumed to be in the same spatial reference system.
+In the following examples we use a polygon shapefile representing countries (``countries.shp``) and a raster digital elevation model (``dem.tif``). The data are assumed to be in the same spatial reference system.
 
 GeoJSON inputs
 ^^^^^^^^^^^^^^
@@ -97,7 +97,7 @@ This will print the GeoJSON Features to the terminal (stdout) with Features like
 
     {"type": Feature, "geometry": {...} ,"properties": {...}}
 
-We'll use unix pipes to pass this data directly into our zonal stats command without an intemediate file.
+We'll use unix pipes to pass this data directly into our zonal stats command without an intermediate file.
 
 Specifying the Raster
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Install::
     pip install rasterstats
 
 
-Given a polygon vector layer and a digitial elevation model (DEM) raster:
+Given a polygon vector layer and a digital elevation model (DEM) raster:
 
 .. figure:: https://github.com/perrygeo/python-raster-stats/raw/master/docs/img/zones_elevation.png
    :align: center

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -149,7 +149,7 @@ You can also specify as a space-delimited string::
 
 
 Note that certain statistics (majority, minority, and unique) require significantly more processing
-due to expensive counting of unique occurences for each pixel value.
+due to expensive counting of unique occurrences for each pixel value.
 
 You can also use a percentile statistic by specifying
 ``percentile_<q>`` where ``<q>`` can be a floating point number between 0 and 100.
@@ -174,7 +174,7 @@ then use it in your ``zonal_stats`` call like so::
     ...             add_stats={'mymean':mymean})
     [{'count': 75, 'mymean': 14.660084635416666}, {'count': 50, 'mymean': 56.605761718750003}]
 
-To have access to geometry properties, a dictionnary can be passed to the user-defined function::
+To have access to geometry properties, a dictionary can be passed to the user-defined function::
 
     >>> def mymean_prop(x,prop):
     ...     return np.ma.mean(x) * prop['id']
@@ -221,7 +221,7 @@ There is no right or wrong way to rasterize a vector. The default strategy is to
 
 The figure above illustrates the difference; the default ``all_touched=False`` is on the left
 while the ``all_touched=True`` option is on the right.
-Both approaches are valid and there are tradeoffs to consider. Using the default rasterizer may miss polygons that are smaller than your cell size resulting in ``None`` stats for those geometries. Using the ``all_touched`` strategy includes many cells along the edges that may not be representative of the geometry and may give severly biased results in some cases.
+Both approaches are valid and there are tradeoffs to consider. Using the default rasterizer may miss polygons that are smaller than your cell size resulting in ``None`` stats for those geometries. Using the ``all_touched`` strategy includes many cells along the edges that may not be representative of the geometry and may give severely biased results in some cases.
 
 
 Working with categorical rasters
@@ -288,7 +288,7 @@ and standard interfaces like GeoJSON are employed to keep the core library lean.
 
 History
 --------
-This work grew out of a need to have a native python implementation (based on numpy) for zonal statisics.
+This work grew out of a need to have a native python implementation (based on numpy) for zonal statistics.
 I had been `using starspan <http://www.perrygeo.com/starspan-for-vector-on-raster-analysis.html>`_, a C++
 command line tool, as well as GRASS's `r.statistics <https://grass.osgeo.org/grass70/manuals/r.statistics.html>`_ for many years.
 They were suitable for offline analyses but were rather clunky to deploy in a large python application.

--- a/src/rasterstats/cli.py
+++ b/src/rasterstats/cli.py
@@ -91,10 +91,10 @@ def pointquery(features, raster, band, indent, nodata,
     The raster values are added to the features properties and output as GeoJSON
     Feature Collection.
 
-    If the Features are Points, the point geometery is used.
-    For other Feauture types, all of the verticies of the geometry will be queried.
+    If the Features are Points, the point geometry is used.
+    For other Feauture types, all of the vertices of the geometry will be queried.
     For example, you can provide a linestring and get the profile along the line
-    if the verticies are spaced properly.
+    if the vertices are spaced properly.
 
     You can use either bilinear (default) or nearest neighbor interpolation.
     """


### PR DESCRIPTION
There are small typos in:
- docs/cli.rst
- docs/index.rst
- docs/manual.rst
- src/rasterstats/cli.py

Fixes:
- Should read `digital` rather than `digitial`.
- Should read `vertices` rather than `verticies`.
- Should read `statistics` rather than `statisics`.
- Should read `severely` rather than `severly`.
- Should read `occurrences` rather than `occurences`.
- Should read `intermediate` rather than `intemediate`.
- Should read `geometry` rather than `geometery`.
- Should read `dictionary` rather than `dictionnary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md