### PR TITLE
Multigeometries

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -164,12 +164,12 @@ def gen_zonal_stats(
                 isnodata = None
                 
                 #iterate through individual polygons
-                for singlePolygon in geom.geoms:
-                    polygon_bounds = tuple(singlePolygon.bounds)
+                for single_polygon in geom.geoms:
+                    polygon_bounds = tuple(single_polygon.bounds)
                     polygon_fsrc = rast.read(bounds=polygon_bounds)
 
                     # rasterized geometry
-                    polygon_rv_array = rasterize_geom(singlePolygon, like=polygon_fsrc, all_touched=all_touched)
+                    polygon_rv_array = rasterize_geom(single_polygon, like=polygon_fsrc, all_touched=all_touched)
 
                     # nodata mask
                     polygon_isnodata = (polygon_fsrc.array == polygon_fsrc.nodata)


### PR DESCRIPTION
Here is the code to enable the "split_multi_geom" option for zonal_stats as we discussed.  It reads individual polygons in a multipolygon type of geometry to save memory usage.

I only did a bare minimum of testing against the slope.tif and multipolygon.shp inside the test directory.  I don't really have the data and time to do more extensive testing.  So perhaps some of the users asking for this feature can do some tests.