### PR TITLE
add multiband zonalstats support

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -239,7 +239,7 @@ class Raster(object):
     read
     """
 
-    def __init__(self, raster, affine=None, nodata=None, band=1):
+    def __init__(self, raster, affine=None, nodata=None, band=None):
         self.array = None
         self.src = None
 
@@ -323,8 +323,12 @@ class Raster(object):
                     masked = True
                     warnings.warn("Setting masked to True because dataset mask has been detected")
 
-            new_array = self.src.read(
-                self.band, window=win, boundless=boundless, masked=masked)
+            if self.band is None:
+                new_array = self.src.read(
+                    window=win, boundless=boundless, masked=masked)
+            else:
+                new_array = self.src.read(
+                    self.band, window=win, boundless=boundless, masked=masked)
 
         return Raster(new_array, new_affine, nodata)
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -35,7 +35,7 @@ def zonal_stats(*args, **kwargs):
 def gen_zonal_stats(
         vectors, raster,
         layer=0,
-        band=1,
+        band=None,
         nodata=None,
         affine=None,
         stats=None,

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -40,7 +40,7 @@ def rasterize_geom(geom, like, all_touched=False):
     geoms = [(geom, 1)]
     rv_array = features.rasterize(
         geoms,
-        out_shape=like.shape,
+        out_shape=like.shape[-2:],
         transform=like.affine,
         fill=0,
         dtype='uint8',


### PR DESCRIPTION
This PR is supposed to add support for zonal statistics of multiband raster data, similar to the issue raised in #73 . If you for example want to calculate the hue for each zone, this can't be done using the bands separately. I also suggest that the default behaviour changes to using all bands rather than only the 1st band, which seems arbitrary if multiband is supported. In addition to the tests in the tests directory, i have tested with some custom metrics, like hue, for which it seems to work fine. I don't know the details of the implemented tests and default metrics, so it could be some of the metrics don't make sense in the multiband case.