### PR TITLE
PEP-518: specify minimum build system requirements with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-python setup.py sdist --formats=gztar,zip bdist_wheel
+python -m build
 # Redirect any warnings and check for failures
-if [[ -n $(twine check dist/* 2>/dev/null | grep "Failed") ]]; then
+if [[ -n $(twine check --strict dist/* 2>/dev/null | grep "Failed") ]]; then
     echo "Detected invalid markup, exiting!"
     exit 1
 fi

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     package_dir={'': 'src'},
     packages=['rasterstats'],
     long_description=read('README.rst'),
+    long_description_content_type='text/x-rst',
     install_requires=read('requirements.txt').splitlines(),
     tests_require=['pytest', 'pytest-cov>=2.2.0', 'pyshp>=1.1.4',
                    'coverage', 'simplejson'],


### PR DESCRIPTION
This implements [PEP 518](https://peps.python.org/pep-0518/) by adding a `pyproject.toml` file with the build system requirements.

Also a few related things:
- Use `python -m build` to build sdist (.tar.gz) and wheel files
- Use `twine check --strict` to raise error on warnings, and...
- Add `long_description_content_type='text/x-rst'` to fix `twine check --strict`