### PR TITLE
Resolve shapely deprecation warnings; use pytest.importorskip

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -14,9 +14,9 @@ import numpy as np
 from shapely import wkt, wkb
 
 try:
-    from shapely.errors import ReadingError
+    from shapely.errors import ShapelyError
 except ImportError:  # pragma: no cover
-    from shapely.geos import ReadingError
+    from shapely.errors import ReadingError as ShapelyError
 
 try:
     from json.decoder import JSONDecodeError
@@ -58,14 +58,14 @@ def parse_feature(obj):
     try:
         shape = wkt.loads(obj)
         return wrap_geom(shape.__geo_interface__)
-    except (ReadingError, TypeError, AttributeError):
+    except (ShapelyError, TypeError, AttributeError):
         pass
 
     # wkb
     try:
         shape = wkb.loads(obj)
         return wrap_geom(shape.__geo_interface__)
-    except (ReadingError, TypeError):
+    except (ShapelyError, TypeError):
         pass
 
     # geojson-like python mapping

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -153,7 +153,7 @@ def gen_zonal_stats(
         for _, feat in enumerate(features_iter):
             geom = shape(feat['geometry'])
 
-            if 'Point' in geom.type:
+            if 'Point' in geom.geom_type:
                 geom = boxify_points(geom, rast)
 
             geom_bounds = tuple(geom.bounds)

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -130,14 +130,14 @@ def boxify_points(geom, rast):
     Point and MultiPoint don't play well with GDALRasterize
     convert them into box polygons 99% cellsize, centered on the raster cell
     """
-    if 'Point' not in geom.type:
+    if 'Point' not in geom.geom_type:
         raise ValueError("Points or multipoints only")
 
     buff = -0.01 * abs(min(rast.affine.a, rast.affine.e))
 
-    if geom.type == 'Point':
+    if geom.geom_type == 'Point':
         pts = [geom]
-    elif geom.type == "MultiPoint":
+    elif geom.geom_type == "MultiPoint":
         pts = geom.geoms
     geoms = []
     for pt in pts:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -369,13 +369,11 @@ def test_geointerface():
 
 # Optional tests
 def test_geodataframe():
-    try:
-        import geopandas as gpd
-        df = gpd.read_file(polygons)
-        if not hasattr(df, '__geo_interface__'):
-            pytest.skip("This version of geopandas doesn't support df.__geo_interface__")
-    except ImportError:
-        pytest.skip("Can't import geopands")
+    gpd = pytest.importorskip("geopandas")
+
+    df = gpd.read_file(polygons)
+    if not hasattr(df, '__geo_interface__'):
+        pytest.skip("This version of geopandas doesn't support df.__geo_interface__")
     assert list(read_features(df))
 
 

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -500,7 +500,7 @@ def test_geojson_out():
 # since the read_features func for this data type is generating
 # the properties field
 def test_geojson_out_with_no_properties():
-    polygon = Polygon([[0, 0], [0, 0,5], [1, 1.5], [1.5, 2], [2, 2], [2, 0]])
+    polygon = Polygon([[0, 0], [0, 0.5], [1, 1.5], [1.5, 2], [2, 2], [2, 0]])
     arr = np.array([
         [100, 1],
         [100, 1]
@@ -559,15 +559,12 @@ def test_nan_counts():
 
 # Optional tests
 def test_geodataframe_zonal():
-    polygons = os.path.join(DATA, 'polygons.shp')
+    gpd = pytest.importorskip("geopandas")
 
-    try:
-        import geopandas as gpd
-        df = gpd.read_file(polygons)
-        if not hasattr(df, '__geo_interface__'):
-            pytest.skip("This version of geopandas doesn't support df.__geo_interface__")
-    except ImportError:
-        pytest.skip("Can't import geopands")
+    polygons = os.path.join(DATA, 'polygons.shp')
+    df = gpd.read_file(polygons)
+    if not hasattr(df, '__geo_interface__'):
+        pytest.skip("This version of geopandas doesn't support df.__geo_interface__")
 
     expected = zonal_stats(polygons, raster)
     assert zonal_stats(df, raster) == expected


### PR DESCRIPTION
This PR resolves a few shapely deprecation warnings:

- Use `shapely.errors.ShapelyError` (`ReadingError` was also only from `shapely.errors`)
- Use `geom.geom_type` instead of `geom.type`
- Fix inconsistent dimensionality error with test polygon
- Use [`pytest.importorskip`](https://docs.pytest.org/en/7.1.x/how-to/skipping.html#skipping-on-a-missing-import-dependency) feature