### PR TITLE
Make int64 casting optional

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -253,6 +253,16 @@ you can use a ``category_map``::
     ...             categorical=True, category_map=cmap)[1]
     {'high': 40, 'med': 9, 'low': 1}
 
+You can also specify `cast_to_int64=False` to prevent casting the ndarray
+read from the raster to int64 on 64bit systems.  This will result in significant
+memory savings on datasets that user smaller datatypes, such as bytes ::
+
+    >>> zonal_stats('tests/data/polygons.shp',
+    ...             'tests/data/slope_classes.tif',
+    ...             categorical=True,
+                    cast_to_int64=False)[1]
+    {1.0: 1, 2.0: 9, 5.0: 40}
+
 "Mini-Rasters"
 ^^^^^^^^^^^^^^^
 

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -121,8 +121,9 @@ def gen_zonal_stats(
 
     cast_to_int64: boolean
         Cast the numpy array read from the raster to int64 if it is an integer
-        type.  This prevents inconsistent behaviour between windows and linux,
-        at the cost of increased memory usage. Raster data containing bytes will
+        type.  This prevents inconsistent behaviour between windows and linux
+        (https://github.com/numpy/numpy/issues/8433), at the cost of increased
+        memory usage. Raster data containing bytes will
         take 8 times as much memory if this is set to true.  Defaults to
         sys.maxsize > 2**32 (defaults to true on 64 bit machines)
         
@@ -136,6 +137,7 @@ def gen_zonal_stats(
         GeoJSON-like Feature as python dict
     """
     cast_to_int64 = cast_to_int64 or sys.maxsize > 2**32
+
     stats, run_count = check_stats(stats, categorical)
 
     # Handle 1.0 deprecations


### PR DESCRIPTION
With 'large' raster datasets of integer datatype, rasterstats wastefully casts the ndarray read from the raster up to int64.  In the extreme case, this uses 8 times more memory than necessary if the underlying datatype of the raster dataset is Byte.

At least for categorical rasters and when using `categorical=True`, it seems desirable to disable this behaviour to save memory.

In a not particularly extreme case, this saved us on the order of 20G of memory:

The raster datasets covers all of Scotland and is of the Byte type.  The individual features in the vector dataset are the Scottish country boundaries and therefore cover a decent portion of the raster area (and their bounding box an even larger portion).

The raster dataset is 46478 * 69365 pixels, 1 byte per pixel = 3.00GiB uncompressed in memory if stored in an ndarray of dtype int8.  It would be 24GiB in int64.