### PR TITLE
Warn about Nodata only once

### DIFF
--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -219,7 +219,7 @@ def boundless_array(arr, window, nodata, masked=False):
     return out
 
 
-class NodataWarning(RuntimeWarning):
+class NodataWarning(UserWarning):
     pass
 
 


### PR DESCRIPTION
The python warnings filter is buggy and does not respect the `once` action. This is particularly annoying for the nodata warnings as its called on every feature.

This PR implements a hack using a global bool to avoid repeat warnings.

Should clean up the logs for anyone who uses arrays directly as rasters.