### PR TITLE
Python 3 upgrades

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # rasterstats documentation build configuration file, created by
 # sphinx-quickstart on Mon Aug 31 09:59:38 2015.
@@ -73,14 +72,14 @@ def get_version():
     vfile = os.path.join(
         os.path.dirname(__file__), "..", "src", "rasterstats", "_version.py"
     )
-    with open(vfile, "r") as vfh:
+    with open(vfile) as vfh:
         vline = vfh.read()
     vregex = r"^__version__ = ['\"]([^'\"]*)['\"]"
     match = re.search(vregex, vline, re.M)
     if match:
         return match.group(1)
     else:
-        raise RuntimeError("Unable to find version string in {}.".format(vfile))
+        raise RuntimeError(f"Unable to find version string in {vfile}.")
 
 
 version = ".".join(get_version().split(".")[0:2])

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 """
 First, download the data and place in `benchmark_data`
 

--- a/src/rasterstats/__init__.py
+++ b/src/rasterstats/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .main import gen_zonal_stats, raster_stats, zonal_stats
 from .point import gen_point_query, point_query
 from rasterstats import cli

--- a/src/rasterstats/cli.py
+++ b/src/rasterstats/cli.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
 import logging
 
 import click

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
 import json
 import math
 import fiona
@@ -26,7 +23,7 @@ except ImportError:  # pragma: no cover
 try:
     from collections.abc import Iterable, Mapping
 except ImportError:  # pragma: no cover
-    from collections import Iterable, Mapping
+    from collections.abc import Iterable, Mapping
 
 
 geom_types = [
@@ -93,18 +90,10 @@ def read_features(obj, layer=0):
 
             def fiona_generator(obj):
                 with fiona.open(obj, "r", layer=layer) as src:
-                    for feature in src:
-                        yield feature
+                    yield from src
 
             features_iter = fiona_generator(obj)
-        except (
-            AssertionError,
-            TypeError,
-            IOError,
-            OSError,
-            DriverError,
-            UnicodeDecodeError,
-        ):
+        except (AssertionError, TypeError, OSError, DriverError, UnicodeDecodeError):
             try:
                 mapping = json.loads(obj)
                 if "type" in mapping and mapping["type"] == "FeatureCollection":
@@ -229,7 +218,7 @@ class NodataWarning(UserWarning):
 already_warned_nodata = False
 
 
-class Raster(object):
+class Raster:
     """Raster abstraction for data access to 2/3D array-like things
 
     Use as a context manager to ensure dataset gets closed properly::
@@ -284,7 +273,7 @@ class Raster(object):
 
     def index(self, x, y):
         """Given (x, y) in crs, return the (row, column) on the raster"""
-        col, row = [math.floor(a) for a in (~self.affine * (x, y))]
+        col, row = (math.floor(a) for a in (~self.affine * (x, y)))
         return row, col
 
     def read(self, bounds=None, window=None, masked=False, boundless=True):

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-
 import sys
 import warnings
 
@@ -202,11 +198,8 @@ def gen_zonal_stats(
             if zone_func is not None:
                 if not callable(zone_func):
                     raise TypeError(
-                        (
-                            "zone_func must be a callable "
-                            "which accepts function a "
-                            "single `zone_array` arg."
-                        )
+                        "zone_func must be a callable function "
+                        "which accepts a single `zone_array` arg."
                     )
                 value = zone_func(masked)
 
@@ -216,7 +209,7 @@ def gen_zonal_stats(
 
             if masked.compressed().size == 0:
                 # nothing here, fill with None and move on
-                feature_stats = dict([(stat, None) for stat in stats])
+                feature_stats = {stat: None for stat in stats}
                 if "count" in stats:  # special case, zero makes sense here
                     feature_stats["count"] = 0
             else:
@@ -304,7 +297,7 @@ def gen_zonal_stats(
             if prefix is not None:
                 prefixed_feature_stats = {}
                 for key, val in feature_stats.items():
-                    newkey = "{}{}".format(prefix, key)
+                    newkey = f"{prefix}{key}"
                     prefixed_feature_stats[newkey] = val
                 feature_stats = prefixed_feature_stats
 

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
 from shapely.geometry import shape
 from shapely.ops import transform
 from numpy.ma import masked
@@ -85,8 +83,7 @@ def geom_xys(geom):
             for interior in g.interiors:
                 yield from geom_xys(interior)
         else:
-            for pair in g.coords:
-                yield pair
+            yield from g.coords
 
 
 def point_query(*args, **kwargs):

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
 import sys
 from rasterio import features
 from shapely.geometry import box, MultiPolygon
@@ -76,8 +73,8 @@ def stats_to_csv(stats):
 
     fieldnames = sorted(list(keys), key=str)
 
-    csvwriter = csv.DictWriter(csv_fh, delimiter=str(","), fieldnames=fieldnames)
-    csvwriter.writerow(dict((fn, fn) for fn in fieldnames))
+    csvwriter = csv.DictWriter(csv_fh, delimiter=",", fieldnames=fieldnames)
+    csvwriter.writerow({fn: fn for fn in fieldnames})
     for row in stats:
         csvwriter.writerow(row)
     contents = csv_fh.getvalue()

--- a/tests/myfunc.py
+++ b/tests/myfunc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # Additional functions to be used in raster stat computation
-from __future__ import division
 import numpy as np
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_cli_feature_stdin():
     result = runner.invoke(
         zonalstats,
         ["--raster", raster, "--stats", "all", "--prefix", "test_"],
-        input=open(vector, "r").read(),
+        input=open(vector).read(),
     )
     assert result.exit_code == 0
     outdata = json.loads(result.output)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -347,7 +347,7 @@ def test_Raster_context():
 
 
 def test_geointerface():
-    class MockGeo(object):
+    class MockGeo:
         def __init__(self, features):
             self.__geo_interface__ = {"type": "FeatureCollection", "features": features}
 

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -65,7 +65,7 @@ def test_nonsense():
     polygons = os.path.join(DATA, "polygons.shp")
     with pytest.raises(ValueError):
         zonal_stats("blaghrlargh", raster)
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         zonal_stats(polygons, "blercherlerch")
     with pytest.raises(ValueError):
         zonal_stats(
@@ -257,9 +257,9 @@ def _assert_dict_eq(a, b):
             continue
         try:
             if abs(a[k] - b[k]) > err:
-                raise AssertionError("{}: {} != {}".format(k, a[k], b[k]))
+                raise AssertionError(f"{k}: {a[k]} != {b[k]}")
         except TypeError:  # can't take abs, nan
-            raise AssertionError("{} != {}".format(a[k], b[k]))
+            raise AssertionError(f"{a[k]} != {b[k]}")
 
 
 def test_ndarray():


### PR DESCRIPTION
This was mostly automated using [pyupgrade](https://github.com/asottile/pyupgrade), which does several things mostly related to Python 2 to 3 upgrades:

- The default encoding for Python 3 is utf-8 ([PEP 3120](https://peps.python.org/pep-3120/)), so no need to specify this
- Remove old `from __future__` imports
- Use `yield from` statement ([PEP 380](https://peps.python.org/pep-0380/))
- Use `OSError` instead of the `IOError` alias ([PEP 3151](https://peps.python.org/pep-3151/))
- The default second argument to `open()` is `"r"`, so this is removed. This one could be controversial, but the contexts where this is done it is clear the file is being read.

The only manual edit is to rephrase an exception message in src/rasterstats/main.py