### PR TITLE
Sort and absolufy imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
-import shlex
 import re
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -15,8 +15,9 @@ Runtime history:
    1bc8711 130.93s MacBook Pro (Retina, 15-inch, Mid 2014) 2.2GHz i7, 16GB RAM
    2277962  80.68s MacBook Pro (Retina, 15-inch, Mid 2014) 2.2GHz i7, 16GB RAM
 """
-from rasterstats import zonal_stats
 import time
+
+from rasterstats import zonal_stats
 
 
 class Timer:

--- a/examples/multiproc.py
+++ b/examples/multiproc.py
@@ -2,9 +2,9 @@
 import itertools
 import multiprocessing
 
-from rasterstats import zonal_stats
 import fiona
 
+from rasterstats import zonal_stats
 
 shp = "benchmark_data/ne_50m_admin_0_countries.shp"
 tif = "benchmark_data/srtm.tif"

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,9 +1,9 @@
+from pprint import pprint
+
 from rasterstats import zonal_stats
 
 polys = "../tests/data/multilines.shp"
 raster = "../tests/data/slope.tif"
 stats = zonal_stats(polys, raster, stats="*")
-
-from pprint import pprint
 
 pprint(stats)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,7 @@ version = {attr = "rasterstats._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.isort]
+profile = "black"
+known_first_party = ["rasterstats"]

--- a/src/rasterstats/__init__.py
+++ b/src/rasterstats/__init__.py
@@ -1,9 +1,11 @@
-from .main import gen_zonal_stats, raster_stats, zonal_stats
-from .point import gen_point_query, point_query
+# isort: skip_file
+from rasterstats.main import gen_zonal_stats, raster_stats, zonal_stats
+from rasterstats.point import gen_point_query, point_query
 from rasterstats import cli
 from rasterstats._version import __version__
 
 __all__ = [
+    "__version__",
     "gen_zonal_stats",
     "gen_point_query",
     "raster_stats",

--- a/src/rasterstats/cli.py
+++ b/src/rasterstats/cli.py
@@ -4,7 +4,7 @@ import click
 import cligj
 import simplejson as json
 
-from rasterstats import gen_zonal_stats, gen_point_query
+from rasterstats import gen_point_query, gen_zonal_stats
 from rasterstats._version import __version__ as version
 
 SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -1,29 +1,22 @@
 import json
 import math
-import fiona
-from fiona.errors import DriverError
-import rasterio
 import warnings
-from rasterio.transform import guard_transform
-from rasterio.enums import MaskFlags
-from affine import Affine
+from collections.abc import Iterable, Mapping
+from json import JSONDecodeError
+
+import fiona
 import numpy as np
-from shapely import wkt, wkb
+import rasterio
+from affine import Affine
+from fiona.errors import DriverError
+from rasterio.enums import MaskFlags
+from rasterio.transform import guard_transform
+from shapely import wkb, wkt
 
 try:
     from shapely.errors import ShapelyError
 except ImportError:  # pragma: no cover
     from shapely.errors import ReadingError as ShapelyError
-
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:  # pragma: no cover
-    JSONDecodeError = ValueError
-
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:  # pragma: no cover
-    from collections.abc import Iterable, Mapping
 
 
 geom_types = [

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -1,18 +1,18 @@
 import sys
 import warnings
 
+import numpy as np
 from affine import Affine
 from shapely.geometry import shape
-import numpy as np
 
-from .io import read_features, Raster
-from .utils import (
-    rasterize_geom,
-    get_percentile,
-    check_stats,
-    remap_categories,
-    key_assoc_val,
+from rasterstats.io import Raster, read_features
+from rasterstats.utils import (
     boxify_points,
+    check_stats,
+    get_percentile,
+    key_assoc_val,
+    rasterize_geom,
+    remap_categories,
 )
 
 

--- a/src/rasterstats/point.py
+++ b/src/rasterstats/point.py
@@ -1,7 +1,8 @@
+from numpy.ma import masked
 from shapely.geometry import shape
 from shapely.ops import transform
-from numpy.ma import masked
-from .io import read_features, Raster
+
+from rasterstats.io import Raster, read_features
 
 
 def point_window_unitxy(x, y, affine):

--- a/src/rasterstats/utils.py
+++ b/src/rasterstats/utils.py
@@ -1,8 +1,7 @@
-import sys
 from rasterio import features
-from shapely.geometry import box, MultiPolygon
-from .io import window_bounds
+from shapely.geometry import MultiPolygon, box
 
+from rasterstats.io import window_bounds
 
 DEFAULT_STATS = ["count", "min", "max", "mean"]
 VALID_STATS = DEFAULT_STATS + [
@@ -57,14 +56,10 @@ def rasterize_geom(geom, like, all_touched=False):
 
 
 def stats_to_csv(stats):
-    if sys.version_info[0] >= 3:
-        from io import StringIO as IO  # pragma: no cover
-    else:
-        from cStringIO import StringIO as IO  # pragma: no cover
-
     import csv
+    from io import StringIO
 
-    csv_fh = IO()
+    csv_fh = StringIO()
 
     keys = set()
     for stat in stats:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,13 @@
-import os.path
 import json
+import os.path
 import warnings
+
+from click.testing import CliRunner
+
+from rasterstats.cli import pointquery, zonalstats
 
 # Some warnings must be ignored to parse output properly
 # https://github.com/pallets/click/issues/371#issuecomment-223790894
-
-from click.testing import CliRunner
-from rasterstats.cli import zonalstats, pointquery
 
 
 def test_cli_feature():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,17 +1,21 @@
-import sys
-import os
-import fiona
-import rasterio
 import json
-import pytest
-from shapely.geometry import shape
-from rasterstats.io import (
-    read_features,
-    read_featurecollection,
-    Raster,
-)  # todo parse_feature
-from rasterstats.io import boundless_array, window_bounds, bounds_window, rowcol
+import os
+import sys
 
+import fiona
+import pytest
+import rasterio
+from shapely.geometry import shape
+
+from rasterstats.io import (  # todo parse_feature
+    Raster,
+    boundless_array,
+    bounds_window,
+    read_featurecollection,
+    read_features,
+    rowcol,
+    window_bounds,
+)
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,7 +1,9 @@
 import os
+
 import rasterio
-from rasterstats.point import point_window_unitxy, bilinear, geom_xys
+
 from rasterstats import point_query
+from rasterstats.point import bilinear, geom_xys, point_window_unitxy
 
 raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
 raster_nodata = os.path.join(os.path.dirname(__file__), "data/slope_nodata.tif")
@@ -117,12 +119,12 @@ def test_point_query_nodata():
 
 def test_geom_xys():
     from shapely.geometry import (
-        Point,
-        MultiPoint,
         LineString,
         MultiLineString,
-        Polygon,
+        MultiPoint,
         MultiPolygon,
+        Point,
+        Polygon,
     )
 
     pt = Point(0, 0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,17 @@
-import sys
 import os
+import sys
+
 import pytest
 from shapely.geometry import LineString
+
+from rasterstats import zonal_stats
 from rasterstats.utils import (
-    stats_to_csv,
+    VALID_STATS,
+    boxify_points,
     get_percentile,
     remap_categories,
-    boxify_points,
+    stats_to_csv,
 )
-from rasterstats import zonal_stats
-from rasterstats.utils import VALID_STATS
-
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -1,17 +1,18 @@
 # test zonal stats
 import json
 import os
-import pytest
-import simplejson
 import sys
 
 import numpy as np
+import pytest
 import rasterio
-from rasterstats import zonal_stats, raster_stats
-from rasterstats.utils import VALID_STATS
-from rasterstats.io import read_featurecollection, read_features
-from shapely.geometry import Polygon
+import simplejson
 from affine import Affine
+from shapely.geometry import Polygon
+
+from rasterstats import raster_stats, zonal_stats
+from rasterstats.io import read_featurecollection, read_features
+from rasterstats.utils import VALID_STATS
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
This PR simplifies and tidies imports using [isort](https://pycqa.github.io/isort/) and [absolufy-imports](https://github.com/MarcoGorelli/absolufy-imports). Other unused imports are cleaned up, as well as a few manual edits related to imports.

This brings consistency of imports, and [PEP 8](https://peps.python.org/pep-0008/) recommends absolute imports (previously a mixture of relative and absolute were used).