### PR TITLE
Add rv_array to custom functions

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import warnings
 
@@ -283,10 +284,14 @@ def gen_zonal_stats(
 
             if add_stats is not None:
                 for stat_name, stat_func in add_stats.items():
-                    try:
+                    n_params = len(inspect.signature(stat_func).parameters.keys())
+                    if n_params == 3:
+                        feature_stats[stat_name] = stat_func(masked, feat["properties"], rv_array)
+                    # backwards compatible with two-argument function
+                    elif n_params == 2:
                         feature_stats[stat_name] = stat_func(masked, feat["properties"])
-                    except TypeError:
-                        # backwards compatible with single-argument function
+                    # backwards compatible with single-argument function
+                    else:
                         feature_stats[stat_name] = stat_func(masked)
 
             if raster_out:

--- a/tests/test_zonal.py
+++ b/tests/test_zonal.py
@@ -315,6 +315,18 @@ def test_add_stats_prop():
     for i in range(len(stats)):
         assert stats[i]["mymean_prop"] == stats[i]["mean"] * (i + 1)
 
+def test_add_stats_prop_and_array():
+    polygons = os.path.join(DATA, "polygons.shp")
+
+    def mymean_prop_and_array(x, prop, rv_array):
+        # confirm that the object exists and is accessible.
+        assert rv_array is not None
+        return np.ma.mean(x) * prop["id"]
+
+    stats = zonal_stats(polygons, raster, add_stats={"mymean_prop_and_array": mymean_prop_and_array})
+    for i in range(len(stats)):
+        assert stats[i]["mymean_prop_and_array"] == stats[i]["mean"] * (i + 1)
+
 
 def test_mini_raster():
     polygons = os.path.join(DATA, "polygons.shp")


### PR DESCRIPTION
This PR is giving access to the `rv_array` within custom functions to build more advanced stats.


----

We are using zonal_stats within a project for the United Nations to calculate intersect areas and percentages. Because the nodata filter gets applied to the mask beforehand, we found it difficult to calculate the intersect percentage with custom functions. We resorted to calculating as a combination of metrics, see https://github.com/WFP-VAM/prism-app/pull/893. But it would be great to have access to the rv_array to give users a bit more flexibility to implement more complex statistics.

This is an attempt to do just that :)

PS - super grateful for your project @perrygeo !