### PR TITLE
add gdf_zonal_stat to main.py

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -36,6 +36,26 @@ def zonal_stats(*args, **kwargs):
     return list(gen_zonal_stats(*args, **kwargs))
 
 
+def gdf_zonal_stats(vectors, *args, **kwargs):
+    """The primary zonal statistics entry point.
+
+    All arguments are passed directly to ``gen_zonal_stats``.
+    See its docstring for details.
+    
+    The difference is that ``gdf_zonal_stats`` will
+    return a GeoDataFrame rather than a generator.
+    Besides this, we make sure the new gdf as the right
+    metadata by conserving the CRS
+    """
+    
+    gdf = gpd.GeoDataFrame.from_features(
+        list(gen_zonal_stats(vectors, geojson_out=True, *args, **kwargs))
+        )
+    gdf.crs = vectors.crs
+    
+    return gdf
+
+
 def gen_zonal_stats(
     vectors,
     raster,


### PR DESCRIPTION
Hello,
I am not sure it's the best way to do this but I would like to propose a function to get the result of the zonal stat directly as a Geodataframe to keep all the properties and the geometry together with the initial vectors CRS. I you think there's a more efficient way to do this I would be happy to ear it.