### PR TITLE
ci: test against python 3.12, drop 3.7

### DIFF
--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         pytest
     - name: Test with older packages
+      if: ${{ matrix.python-minor-version < 11 }}  # only for python <=3.11
       run: |
         python -m pip uninstall --yes geopandas
         python -m pip install "fiona<1.9" "shapely<2.0"

--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -24,8 +24,9 @@ jobs:
     - name: Test all packages
       run: |
         pytest
-    - name: Test with older packages
-      if: ${{ matrix.python-minor-version < 11 }}  # only for python <=3.11
+    - name: Test with older packages and older pythons
+      # wheel only available for python <=3.11
+      if: contains(fromJson('["3.8", "3.9", "3.10", "3.11"]'), ${{ matrix.python-version }})
       run: |
         python -m pip uninstall --yes geopandas
         python -m pip install "fiona<1.9" "shapely<2.0"

--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -20,14 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install pip --upgrade
-        python -m pip install -e .[dev]
+        python -m pip install -e ".[dev]"
     - name: Test all packages
       run: |
-        pytest
-    - name: Test with older packages and older pythons
-      # wheel only available for python <=3.11
-      if: contains(fromJson('["3.8", "3.9", "3.10", "3.11"]'), ${{ matrix.python-version }})
-      run: |
-        python -m pip uninstall --yes geopandas
-        python -m pip install "fiona<1.9" "shapely<2.0"
         pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Utilities",
     "Topic :: Scientific/Engineering :: GIS",
 ]

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -270,7 +270,7 @@ def gen_zonal_stats(
                 for pctile in [s for s in stats if s.startswith("percentile_")]:
                     q = get_percentile(pctile)
                     pctarr = masked.compressed()
-                    feature_stats[pctile] = np.percentile(pctarr, q)
+                    feature_stats[pctile] = float(np.percentile(pctarr, q))
 
             if "nodata" in stats or "nan" in stats:
                 featmasked = np.ma.MaskedArray(fsrc.array, mask=(~rv_array))
@@ -286,7 +286,9 @@ def gen_zonal_stats(
                 for stat_name, stat_func in add_stats.items():
                     n_params = len(inspect.signature(stat_func).parameters.keys())
                     if n_params == 3:
-                        feature_stats[stat_name] = stat_func(masked, feat["properties"], rv_array)
+                        feature_stats[stat_name] = stat_func(
+                            masked, feat["properties"], rv_array
+                        )
                     # backwards compatible with two-argument function
                     elif n_params == 2:
                         feature_stats[stat_name] = stat_func(masked, feat["properties"])


### PR DESCRIPTION
To confirm latest python version is working and keep up with https://devguide.python.org/versions/ 

I removed the test for older dependency versions - they don't work on python 3.12. If our dependencies are not backported to keep up with Python releases, then its not feasible for us to do so.