### PR TITLE
Addressing progress bar issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
 
 
 [project.optional-dependencies]
+progress = [
+    "tqdm"
+]
 test = [
     "coverage",
     "geopandas",

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -16,7 +16,10 @@ from rasterstats.utils import (
     remap_categories,
 )
 
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
 
 
 def raster_stats(*args, **kwargs):
@@ -38,6 +41,10 @@ def zonal_stats(*args, **kwargs):
     return a list rather than a generator."""
     progress = kwargs.get("progress")
     if progress:
+        if tqdm is None:
+            raise ValueError(
+                "You specified progress=True, but tqdm is not installed in the environment. You can do pip install rasterstats[progress] to install tqdm!"
+            )
         stats = gen_zonal_stats(*args, **kwargs)
         total = sum(1 for _ in stats)
         return [stat for stat in tqdm(stats, total=total)]

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -16,6 +16,8 @@ from rasterstats.utils import (
     remap_categories,
 )
 
+from tqdm import tqdm
+
 
 def raster_stats(*args, **kwargs):
     """Deprecated. Use zonal_stats instead."""
@@ -34,7 +36,13 @@ def zonal_stats(*args, **kwargs):
 
     The only difference is that ``zonal_stats`` will
     return a list rather than a generator."""
-    return list(gen_zonal_stats(*args, **kwargs))
+    progress = kwargs.get("progress")
+    if progress:
+        stats = gen_zonal_stats(*args, **kwargs)
+        total = sum(1 for _ in stats)
+        return [stat for stat in tqdm(stats, total=total)]
+    else:
+        return list(gen_zonal_stats(*args, **kwargs))
 
 
 def gen_zonal_stats(


### PR DESCRIPTION
- Added tqdm to main.py in zonal_stats function
    - `stats` generator is created doing `gen_zonal_stats()` and then the total length of the generator (for `tqdm` to know) is done doing `total=sum(1 for _ in stats)`. Not sure how I feel about this.
    - if `progress == True`, the `zonal_stats()` function will return the list comprehension using the `tqdm` module, if not it will return the original generator list-initialization.
- Added tqdm in project.optional-dependencies in pyproject.toml.