### PR TITLE
Fix for fiona 1.10

### DIFF
--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ progress = [
 ]
 test = [
     "coverage",
-    "geopandas",
+    "geopandas <= 1.0",
     "pyshp >=1.1.4",
     "pytest >=4.6",
     "pytest-cov >=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ progress = [
 ]
 test = [
     "coverage",
-    "geopandas <= 1.0",
+    "geopandas",
     "pyshp >=1.1.4",
     "pytest >=4.6",
     "pytest-cov >=2.2.0",

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -97,7 +97,14 @@ def read_features(obj, layer=0):
                 assert len(src) > 0
 
             features_iter = fiona_generator(obj, layer)
-        except (AssertionError, TypeError, OSError, DriverError, UnicodeDecodeError):
+        except (
+            AssertionError,
+            DriverError,
+            OSError,
+            TypeError,
+            UnicodeDecodeError,
+            ValueError,
+        ):
             try:
                 mapping = json.loads(obj)
                 if "type" in mapping and mapping["type"] == "FeatureCollection":


### PR DESCRIPTION
Fiona behavior changed slightly when opening GeoJSON strings. See https://github.com/Toblerity/Fiona/issues/1455

We can work around this in a backwards compatible way by catching the `ValueError` so that GeoJSON strings take the `json.loads` code path. 