### PR TITLE
fix the bug when progress = True

### DIFF
--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -46,7 +46,7 @@ def zonal_stats(*args, **kwargs):
                 "You specified progress=True, but tqdm is not installed in the environment. You can do pip install rasterstats[progress] to install tqdm!"
             )
         stats = gen_zonal_stats(*args, **kwargs)
-        total = sum(1 for _ in stats)
+        total = len(args[0])
         return [stat for stat in tqdm(stats, total=total)]
     else:
         return list(gen_zonal_stats(*args, **kwargs))


### PR DESCRIPTION
As #303 mentioned, generator would be consumed when progress = True related the code below

```
def zonal_stats(*args, **kwargs):
    """The primary zonal statistics entry point.

    All arguments are passed directly to ``gen_zonal_stats``.
    See its docstring for details.

    The only difference is that ``zonal_stats`` will
    return a list rather than a generator."""
    progress = kwargs.get("progress")
    if progress:
        if tqdm is None:
            raise ValueError(
                "You specified progress=True, but tqdm is not installed in the environment. You can do pip install rasterstats[progress] to install tqdm!"
            )
        stats = gen_zonal_stats(*args, **kwargs)
        total = sum(1 for _ in stats)  # note that it will consume the generator stats.
        return [stat for stat in tqdm(stats, total=total)]
    else:
        return list(gen_zonal_stats(*args, **kwargs))
```

So I make a slice change playing the same role

```
total = len(args[0])
```

And the problem seems has been resolved according the result!
