### PR TITLE
Allow path-like objects for vector source; use Path for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "affine",
-    "click >7.1",
+    "click >7.1, !=8.2.1",
     "cligj >=0.4",
     "fiona",
     "numpy >=1.9",
@@ -65,6 +65,14 @@ pointquery = "rasterstats.cli:pointquery"
 [project.urls]
 Documentation = "https://pythonhosted.org/rasterstats/"
 "Source Code" = "https://github.com/perrygeo/python-rasterstats"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore::UserWarning",
+]
+testpaths = ["tests"]
+# addopts = "--verbose -rf --ipdb --maxfail=1"
 
 [tool.setuptools.dynamic]
 version = {attr = "rasterstats._version.__version__"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-filterwarnings =
-    error
-    ignore::UserWarning
-norecursedirs = examples* src* scripts* docs*
-# addopts = --verbose -rf --ipdb --maxfail=1

--- a/src/rasterstats/io.py
+++ b/src/rasterstats/io.py
@@ -3,6 +3,7 @@ import math
 import warnings
 from collections.abc import Iterable, Mapping
 from json import JSONDecodeError
+from os import PathLike
 
 import fiona
 import numpy as np
@@ -90,7 +91,8 @@ def parse_feature(obj):
 
 def read_features(obj, layer=0):
     features_iter = None
-    if isinstance(obj, str):
+    if isinstance(obj, (str, PathLike)):
+        obj = str(obj)
         try:
             # test it as fiona data source
             with fiona.open(obj, "r", layer=layer) as src:

--- a/src/rasterstats/main.py
+++ b/src/rasterstats/main.py
@@ -75,9 +75,11 @@ def gen_zonal_stats(
 
     Parameters
     ----------
-    vectors: path to an vector source or geo-like python objects
+    vectors : str or PathLike
+        Path to an vector source or geo-like python objects.
 
-    raster: ndarray or path to a GDAL raster source
+    raster: array_like, str or PathLike
+        NumPy array or path to a GDAL raster source.
         If ndarray is passed, the ``affine`` kwarg is required.
 
     layer: int or string, optional

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import json
-import os.path
 import warnings
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -9,10 +9,11 @@ from rasterstats.cli import pointquery, zonalstats
 # Some warnings must be ignored to parse output properly
 # https://github.com/pallets/click/issues/371#issuecomment-223790894
 
+data_dir = Path(__file__).parent / "data"
 
 def test_cli_feature():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/feature.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "feature.geojson")
     runner = CliRunner()
     warnings.simplefilter("ignore")
     result = runner.invoke(
@@ -28,15 +29,15 @@ def test_cli_feature():
 
 
 def test_cli_feature_stdin():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/feature.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector_pth = data_dir / "feature.geojson"
 
     runner = CliRunner()
     warnings.simplefilter("ignore")
     result = runner.invoke(
         zonalstats,
         ["--raster", raster, "--stats", "all", "--prefix", "test_"],
-        input=open(vector).read(),
+        input=vector_pth.read_text(),
     )
     assert result.exit_code == 0
     outdata = json.loads(result.output)
@@ -47,8 +48,8 @@ def test_cli_feature_stdin():
 
 
 def test_cli_features_sequence():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         zonalstats,
@@ -71,8 +72,8 @@ def test_cli_features_sequence():
 
 
 def test_cli_features_sequence_rs():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         zonalstats,
@@ -94,8 +95,8 @@ def test_cli_features_sequence_rs():
 
 
 def test_cli_featurecollection():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         zonalstats, [vector, "--raster", raster, "--stats", "mean", "--prefix", "test_"]
@@ -110,8 +111,8 @@ def test_cli_featurecollection():
 
 
 def test_cli_pointquery():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         pointquery, [vector, "--raster", raster, "--property-name", "slope"]
@@ -124,8 +125,8 @@ def test_cli_pointquery():
 
 
 def test_cli_point_sequence():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         pointquery,
@@ -139,8 +140,8 @@ def test_cli_point_sequence():
 
 
 def test_cli_point_sequence_rs():
-    raster = os.path.join(os.path.dirname(__file__), "data/slope.tif")
-    vector = os.path.join(os.path.dirname(__file__), "data/featurecollection.geojson")
+    raster = str(data_dir / "slope.tif")
+    vector = str(data_dir / "featurecollection.geojson")
     runner = CliRunner()
     result = runner.invoke(
         pointquery,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,8 +1,8 @@
 import json
-import os
-import sys
+from pathlib import Path
 
 import fiona
+import numpy as np
 import pytest
 import rasterio
 from shapely.geometry import shape
@@ -18,12 +18,9 @@ from rasterstats.io import (  # todo parse_feature
     window_bounds,
 )
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
-polygons = os.path.join(DATA, "polygons.shp")
-raster = os.path.join(DATA, "slope.tif")
-
-import numpy as np
+data_dir = Path(__file__).parent / "data"
+polygons = data_dir / "polygons.shp"
+raster = data_dir / "slope.tif"
 
 arr = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
 
@@ -59,12 +56,12 @@ def test_fiona_path():
 
 
 def test_layer_index():
-    layer = fiona.listlayers(DATA).index("polygons")
-    assert list(read_features(DATA, layer=layer)) == target_features
+    layer = fiona.listlayers(data_dir).index("polygons")
+    assert list(read_features(data_dir, layer=layer)) == target_features
 
 
 def test_layer_name():
-    assert list(read_features(DATA, layer="polygons")) == target_features
+    assert list(read_features(data_dir, layer="polygons")) == target_features
 
 
 def test_path_unicode():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
-import os
-import sys
+from pathlib import Path
 
 import pytest
 from shapely.geometry import LineString
@@ -13,21 +12,20 @@ from rasterstats.utils import (
     stats_to_csv,
 )
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
-raster = os.path.join(DATA, "slope.tif")
+data_dir = Path(__file__).parent / "data"
+raster = data_dir / "slope.tif"
 
 
 def test_csv():
-    polygons = os.path.join(DATA, "polygons.shp")
+    polygons = data_dir / "polygons.shp"
     stats = zonal_stats(polygons, raster, stats="*")
     csv = stats_to_csv(stats)
     assert csv.split()[0] == ",".join(sorted(VALID_STATS))
 
 
 def test_categorical_csv():
-    polygons = os.path.join(DATA, "polygons.shp")
-    categorical_raster = os.path.join(DATA, "slope_classes.tif")
+    polygons = data_dir / "polygons.shp"
+    categorical_raster = data_dir / "slope_classes.tif"
     stats = zonal_stats(polygons, categorical_raster, categorical=True)
     csv = stats_to_csv(stats)
     assert csv.split()[0] == "1.0,2.0,5.0"


### PR DESCRIPTION
Attempts to use pathlike objects yields an unexpected errror:
```python
from pathlib import Path

polygons = Path(DATA) / "polygons.shp"
stats = zonal_stats(polygons, raster)
# ValueError: Object is not a recognized source of Features
```
This PR allows pathlike vector sources.

Other changes:

- Rewrite tests to use `pathlib` (rather than `os.path`)
- Move `pytest.ini` to `pyproject.toml`, and use `testpaths = ["tests"]` instead of `norecursedirs`