### PR TITLE
ignore the uv.lock file for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ Vagrantfile
 venv
 .eggs
 .cache
+
+# no uv lockfile until this is fixed:
+# https://github.com/astral-sh/uv/issues/10845
+uv.lock


### PR DESCRIPTION
currently experiencing too much churn in the uv lockfile, see https://github.com/astral-sh/uv/issues/10845

Until this is fixed, ie I can use `uv run` without updating my lockfile, I'm going to ignore it. Applications, not libraries, should arguably be setting their own locked dependency sets anyhow.