### PR TITLE
Move "docs", "test" and "dev" to PEP 735 dependency-groups

### DIFF
--- a/.github/workflows/test-rasterstats.yml
+++ b/.github/workflows/test-rasterstats.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install pip --upgrade
-        python -m pip install -e ".[dev]"
+        python -m pip install -e . --group dev
     - name: Test all packages
       run: |
-        pytest
+        pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dependencies = [
 [project.optional-dependencies]
 progress = ["tqdm"]
 fiona = ["fiona; python_version < '3.14'"]
+
+[dependency-groups]
 docs = ["numpydoc", "sphinx", "sphinx-rtd-theme"]
 test = [
   "coverage",
@@ -58,7 +60,12 @@ test = [
   "pytest-cov >=2.2.0",
   "simplejson",
 ]
-dev = ["rasterstats[test,fiona]", "ruff", "twine"]
+dev = [
+  "ruff",
+  "twine",
+  "fiona; python_version < '3.14'",
+  {include-group = "test"},
+]
 
 [project.entry-points."rasterio.rio_plugins"]
 zonalstats = "rasterstats.cli:zonalstats"


### PR DESCRIPTION
This implements [PEP 735](https://peps.python.org/pep-0735/) to use dependency groups for "docs", "test" and "dev". They can be installed with `[uv] pip install ... --group dev`, but also note that the "dev" group is [part of `uv`'s default groups](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups) so it doesn't need to be specified.